### PR TITLE
add socket library depency on SunOS platform

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,11 @@ target_link_libraries(${PROJECT_NAME} ${HIREDIS_STATIC_LIB})
 target_include_directories(${PROJECT_NAME} PUBLIC ../src)
 set(REDIS_PLUS_PLUS_LIB ${CMAKE_CURRENT_BINARY_DIR}/../lib/libredis++.a)
 
+## solaris socket dependency
+IF (CMAKE_SYSTEM_NAME MATCHES "(Solaris|SunOS)" )
+    target_link_libraries(${PROJECT_NAME} -lsocket)
+ENDIF(CMAKE_SYSTEM_NAME MATCHES "(Solaris|SunOS)" )
+
 find_package(Threads REQUIRED)
 
 target_link_libraries(${PROJECT_NAME} ${REDIS_PLUS_PLUS_LIB} ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
I compiled this tools on solaris 11.3(sparc). On Sun/Salaris platform, using socket api should add -lsocket option for the linker.