### PR TITLE
WIP: Add cmake add_subdirectory support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,27 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM debian:9
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Configure apt and install packages
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    # 
+    # Verify git, process tools, lsb-release (useful for CLI installs) installed
+    && apt-get -y install git procps lsb-release \
+    #
+    # Install C++ tools
+    && apt-get -y install build-essential cmake cppcheck valgrind \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// See https://aka.ms/vscode-remote/devcontainer.json for format details.
+{
+	"name": "C++",
+	"dockerFile": "Dockerfile",
+	"runArgs": [
+		"--cap-add=SYS_PTRACE",
+		"--security-opt", "seccomp=unconfined"
+	],
+
+	// Uncomment the next line if you want to publish any ports.
+	// "appPort": [],
+
+	// Uncomment the next line if you want to add in default container specific settings.json values
+	// "settings":  { "workbench.colorTheme": "Quiet Light" },
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "gcc -v",
+
+	"extensions": [
+		"ms-vscode.cpptools"
+	]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Build dir
+build/**
+
 # Prerequisites
 *.d
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "hiredis"]
+	path = hiredis
+	url = https://github.com/redis/hiredis.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,19 +14,25 @@ set(PROJECT_SOURCE_DIR ${PROJECT_SOURCE_DIR}/src/sw/redis++)
 
 file(GLOB PROJECT_SOURCE_FILES "${PROJECT_SOURCE_DIR}/*.cpp")
 
-set(STATIC_LIB static)
-set(SHARED_LIB shared)
+set(STATIC_LIB redis-plus-plus-static)
+set(SHARED_LIB redis-plus-plus-shared)
 
 add_library(${STATIC_LIB} STATIC ${PROJECT_SOURCE_FILES})
 add_library(${SHARED_LIB} SHARED ${PROJECT_SOURCE_FILES})
 
 # hiredis dependency
-find_path(HIREDIS_HEADER hiredis)
-target_include_directories(${STATIC_LIB} PUBLIC ${HIREDIS_HEADER})
-target_include_directories(${SHARED_LIB} PUBLIC ${HIREDIS_HEADER})
+add_subdirectory(hiredis)
+#find_path(HIREDIS_HEADER hiredis)
+set(HIREDIS_HEADER ${CMAKE_SOURCE_DIR})
 
-find_library(HIREDIS_LIB hiredis)
-target_link_libraries(${SHARED_LIB} ${HIREDIS_LIB})
+include_directories(${HIREDIS_HEADER} ${PROJECT_SOURCE_DIR})
+
+#target_include_directories(${STATIC_LIB} PUBLIC ${HIREDIS_HEADER})
+#target_include_directories(${SHARED_LIB} PUBLIC ${HIREDIS_HEADER})
+
+#find_library(HIREDIS_LIB hiredis)
+#target_link_libraries(${SHARED_LIB} ${HIREDIS_LIB})
+target_link_libraries(${SHARED_LIB} hiredis)
 
 set_target_properties(${STATIC_LIB} PROPERTIES OUTPUT_NAME ${PROJECT_NAME})
 set_target_properties(${SHARED_LIB} PROPERTIES OUTPUT_NAME ${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,18 +20,13 @@ set(SHARED_LIB redis-plus-plus-shared)
 add_library(${STATIC_LIB} STATIC ${PROJECT_SOURCE_FILES})
 add_library(${SHARED_LIB} SHARED ${PROJECT_SOURCE_FILES})
 
-# hiredis dependency
-add_subdirectory(hiredis)
-#find_path(HIREDIS_HEADER hiredis)
-set(HIREDIS_HEADER ${CMAKE_SOURCE_DIR})
-
+# Add hiredis and redis-plus-plus to target_include_directories
 include_directories(${HIREDIS_HEADER} ${PROJECT_SOURCE_DIR})
 
-#target_include_directories(${STATIC_LIB} PUBLIC ${HIREDIS_HEADER})
-#target_include_directories(${SHARED_LIB} PUBLIC ${HIREDIS_HEADER})
+# hiredis dependency
+add_subdirectory(hiredis)
+set(HIREDIS_HEADER ${CMAKE_SOURCE_DIR})
 
-#find_library(HIREDIS_LIB hiredis)
-#target_link_libraries(${SHARED_LIB} ${HIREDIS_LIB})
 target_link_libraries(${SHARED_LIB} hiredis)
 
 set_target_properties(${STATIC_LIB} PROPERTIES OUTPUT_NAME ${PROJECT_NAME})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,18 +12,7 @@ file(GLOB PROJECT_SOURCE_FILES "${PROJECT_SOURCE_DIR}/*.cpp")
 
 add_executable(${PROJECT_NAME} ${PROJECT_SOURCE_FILES})
 
-# hiredis dependency
-#find_path(HIREDIS_HEADER hiredis)
-#target_include_directories(${PROJECT_NAME} PUBLIC ${HIREDIS_HEADER})
-
-
-#find_library(HIREDIS_STATIC_LIB libhiredis.a)
-#target_link_libraries(${PROJECT_NAME} ${HIREDIS_STATIC_LIB})
 target_link_libraries(${PROJECT_NAME} hiredis)
-
-# redis++ dependency
-target_include_directories(${PROJECT_NAME} PUBLIC ../src)
-#set(REDIS_PLUS_PLUS_LIB ${CMAKE_CURRENT_BINARY_DIR}/../lib/libredis++.a)
 
 ## solaris socket dependency
 IF (CMAKE_SYSTEM_NAME MATCHES "(Solaris|SunOS)" )
@@ -32,5 +21,4 @@ ENDIF(CMAKE_SYSTEM_NAME MATCHES "(Solaris|SunOS)" )
 
 find_package(Threads REQUIRED)
 
-#target_link_libraries(${PROJECT_NAME} ${REDIS_PLUS_PLUS_LIB} ${CMAKE_THREAD_LIBS_INIT})
 target_link_libraries(${PROJECT_NAME} redis-plus-plus-static ${CMAKE_THREAD_LIBS_INIT})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,15 +13,17 @@ file(GLOB PROJECT_SOURCE_FILES "${PROJECT_SOURCE_DIR}/*.cpp")
 add_executable(${PROJECT_NAME} ${PROJECT_SOURCE_FILES})
 
 # hiredis dependency
-find_path(HIREDIS_HEADER hiredis)
-target_include_directories(${PROJECT_NAME} PUBLIC ${HIREDIS_HEADER})
+#find_path(HIREDIS_HEADER hiredis)
+#target_include_directories(${PROJECT_NAME} PUBLIC ${HIREDIS_HEADER})
 
-find_library(HIREDIS_STATIC_LIB libhiredis.a)
-target_link_libraries(${PROJECT_NAME} ${HIREDIS_STATIC_LIB})
+
+#find_library(HIREDIS_STATIC_LIB libhiredis.a)
+#target_link_libraries(${PROJECT_NAME} ${HIREDIS_STATIC_LIB})
+target_link_libraries(${PROJECT_NAME} hiredis)
 
 # redis++ dependency
 target_include_directories(${PROJECT_NAME} PUBLIC ../src)
-set(REDIS_PLUS_PLUS_LIB ${CMAKE_CURRENT_BINARY_DIR}/../lib/libredis++.a)
+#set(REDIS_PLUS_PLUS_LIB ${CMAKE_CURRENT_BINARY_DIR}/../lib/libredis++.a)
 
 ## solaris socket dependency
 IF (CMAKE_SYSTEM_NAME MATCHES "(Solaris|SunOS)" )
@@ -30,4 +32,5 @@ ENDIF(CMAKE_SYSTEM_NAME MATCHES "(Solaris|SunOS)" )
 
 find_package(Threads REQUIRED)
 
-target_link_libraries(${PROJECT_NAME} ${REDIS_PLUS_PLUS_LIB} ${CMAKE_THREAD_LIBS_INIT})
+#target_link_libraries(${PROJECT_NAME} ${REDIS_PLUS_PLUS_LIB} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${PROJECT_NAME} redis-plus-plus-static ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
Hi,

I am currently working on a project an want to use redis-plus-plus. I am using cmake and want to setup redis-plus-plus as a submodule in my repository and then include it with `add_subdirectory` in my `CMakeLists.txt`. 

The additions I made:
- Prefix both static and shared library target names with 'redis-plus-plus' so my project can use them inside of `target_link_libraries` with a useful name.
- Added both redis-plus-plus and hiredis include directories to `include_directories`.
 - `.devcontainer/*`: I am working on Windows, these files are used by [Visual Studio Code's Remote Containers extension](https://code.visualstudio.com/docs/remote/containers) to develop inside a Docker container that sets up a functional development environment.

If you are interested in these changes, I can also update the documentation.

You need to clone the repository with the `--recursive` flag to get the `hiredis` dependency.
If you have the repository already clone you probably need to run `git submodule update --init --recursive`