### PR TITLE
Enhancement: support for subscriber.consume(int timeout_microseconds) and reconnecting a broken connection in subscriber

### DIFF
--- a/src/sw/redis++/connection.h
+++ b/src/sw/redis++/connection.h
@@ -121,6 +121,8 @@ public:
 
     ReplyUPtr recv();
 
+    ReplyUPtr recv(int timeout_microseconds);
+
     const ConnectionOptions& options() const {
         return _opts;
     }

--- a/src/sw/redis++/subscriber.h
+++ b/src/sw/redis++/subscriber.h
@@ -134,6 +134,16 @@ public:
 
     void consume();
 
+    void consume(int timeout_microseconds);
+    
+    bool is_connection_broken() {
+        return _connection.broken() ? true: false;
+    }
+
+    void reconnect() {
+        _connection.reconnect();
+    }
+
 private:
     friend class Redis;
 


### PR DESCRIPTION
The changes are due to a subscriber.consume method blocking until a message is received. During a blocked consume method, it is not possible to safely call subscribe method. The changes enable the following use case: safely adding new subscriptions:

while (true) {         
  if (!m_queue.IsEmpty()) {
     auto channel = m_queue.Pop();
     m_subscriber.subscribe(channel);
     m_subscriber.consume();
  }
  m_subscriber.consume(CONSUME_TIMEOUT_MICROSECONDS);
  
  if (m_stop) {
    break;
  }
}

Moreover, new subscriber methods "is_broken_connection" and "reconnect" enable reconnecting a subscriber when a connection is broken:

 void EstablishConnection() {
      while (true) {
        try {
          if (!m_subscriber.is_connection_broken()) {
            if (m_logger.isEnabledFor(log4cplus::TRACE_LOG_LEVEL)) {
              LOG4CPLUS_TRACE(m_logger,
                LOG4CPLUS_TEXT("subscriber connection ESTABLISHED. "
                "Subscribing again on channels"));
            }

            for (const auto& channel_name : m_subscribed_channel_names) {
              m_subscriber.subscribe(channel_name);
              m_subscriber.consume();
            }

            break;
          }

          if (m_stop) {
            if (m_logger.isEnabledFor(log4cplus::TRACE_LOG_LEVEL)) {
              LOG4CPLUS_TRACE(m_logger,
                LOG4CPLUS_TEXT("stopping connection establishment"));
            }
            break;
          }

          m_subscriber.reconnect();
          std::this_thread::sleep_for(std::chrono::seconds(CONNECTION_CHECK_TIMEOUT_SEC));
        } catch (const REDISEXCEPTION &err) {
          if (m_logger.isEnabledFor(log4cplus::ERROR_LOG_LEVEL)) {
            LOG4CPLUS_ERROR(m_logger,
              LOG4CPLUS_TEXT("establishing subscriber connection failed: "
              << " What: " << err.what()));
          }
        } catch (const std::exception &err) {
          if (m_logger.isEnabledFor(log4cplus::ERROR_LOG_LEVEL)) {
            LOG4CPLUS_ERROR(m_logger,
              LOG4CPLUS_TEXT("establishing subscriber connection failed with unknown exception: "
              << " What: " << err.what()));
          }
        }
      }
    }
