### PR TITLE
Added single Redis instance Redlock support.

### DIFF
--- a/src/sw/redis++/redlock.cpp
+++ b/src/sw/redis++/redlock.cpp
@@ -1,0 +1,89 @@
+/**************************************************************************
+   Copyright (c) 2019
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*************************************************************************/
+
+#include "redlock.hpp"
+
+namespace sw {
+
+namespace redis {
+
+template <typename T>
+void Redlock<T>::checkAndLoad(Redis& instance, const std::string& sha1, const std::string& scriptString) {
+	std::list<bool> replyList;
+	instance.script_exists({sha1, std::string("")}, std::back_inserter(replyList));
+	if (replyList.size() != 2) {
+		throw Error("script_exists returned an invalid list size.");
+	}
+	else if (!*replyList.begin()) {
+		instance.script_load(scriptString);
+	}
+}
+
+template <>
+bool Redlock<RedisCluster>::extend_lock(const std::string& key, const std::chrono::milliseconds& ttl) {
+	bool result = false;
+	auto item = _randomNumberMap.find(key);
+	if (item != _randomNumberMap.end()) {
+		Redis instance = _instance.redis(key);
+		checkAndLoad(instance, _extendLockSHA1, _extendLockScript);
+		result = instance.evalsha<long long>(_extendLockSHA1, {key}, {item->second, std::to_string(ttl.count())});
+	}
+	return result;
+}
+
+template <>
+bool Redlock<Redis>::extend_lock(const std::string& key, const std::chrono::milliseconds& ttl) {
+	bool result = false;
+	const auto item = _randomNumberMap.find(key);
+	if (item != _randomNumberMap.end()) {
+		result = _instance.evalsha<long long>(_extendLockSHA1, {key}, {item->second, std::to_string(ttl.count())});
+	}
+	return result;
+}
+
+template <>
+void Redlock<RedisCluster>::unlock(const std::string& key) {
+	auto item = _randomNumberMap.find(key);
+	if (item != _randomNumberMap.end()) {
+		Redis instance = _instance.redis(key);
+		checkAndLoad(instance, _unlockSHA1, _unlockScript);
+		instance.evalsha<long long>(_unlockSHA1, {key}, {item->second});
+		_randomNumberMap.erase(item);
+	}
+}
+
+template <>
+void Redlock<Redis>::unlock(const std::string& key) {
+	const auto item = _randomNumberMap.find(key);
+	if (item != _randomNumberMap.end()) {
+		_instance.evalsha<long long>(_unlockSHA1, {key}, {item->second});
+		_randomNumberMap.erase(item);
+	}
+}
+
+template <>
+std::string Redlock<RedisCluster>::loadScript(const std::string& script) {
+	return _instance.redis("").script_load(script);
+}
+
+template <>
+	std::string Redlock<Redis>::loadScript(const std::string& script) {
+	return _instance.script_load(script);
+}
+
+} // namespace sw
+
+} // namespace redis

--- a/src/sw/redis++/redlock.hpp
+++ b/src/sw/redis++/redlock.hpp
@@ -60,6 +60,12 @@ end \
 	{
 	}
 
+	~Redlock() {
+		while (_randomNumberMap.size() > 0) {
+			unlock(_randomNumberMap.begin()->first);
+		}
+	}
+
 	// Only locks if no lock for the supplied key exists.
 	// The lock will stay valid until unlock() is called,
 	// or until the ttl period expired.

--- a/src/sw/redis++/redlock.hpp
+++ b/src/sw/redis++/redlock.hpp
@@ -90,7 +90,6 @@ end \
 	void unlock(const std::string& key);
 
 private:
-	void checkAndLoad(Redis& instance, const std::string& sha1, const std::string& scriptString);
 	std::string loadScript(const std::string& script);
 
 	RandomBufferInterface& _randomBuffer;

--- a/src/sw/redis++/redlock.hpp
+++ b/src/sw/redis++/redlock.hpp
@@ -50,7 +50,7 @@ end \
 "),
 		_extendLockScript("\
 if redis.call(\"GET\",KEYS[1]) == ARGV[1] then \
-  return redis.call(\"expire\",KEYS[1],ARGV[2]) \
+  return redis.call(\"pexpire\",KEYS[1],ARGV[2]) \
 else \
   return 0 \
 end \

--- a/src/sw/redis++/redlock.hpp
+++ b/src/sw/redis++/redlock.hpp
@@ -1,0 +1,103 @@
+/**************************************************************************
+   Copyright (c) 2019
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ *************************************************************************/
+
+#ifndef REDISPLUSPLUS_REDLOCK_H
+#define REDISPLUSPLUS_REDLOCK_H
+
+#include "redis++.h"
+#include <unistd.h>
+#include <openssl/rc4.h>
+
+namespace sw {
+
+namespace redis {
+
+class RandomBufferInterface
+{
+public:
+	virtual ~RandomBufferInterface() {}
+	virtual std::string getUpdatedString() = 0;
+};
+
+template <typename RedisInstance>
+class Redlock
+{
+public:
+	// In the constructor, we load teh scripts and initialize their
+	// SHA1s so that we can check if the script exists, before calling them.
+	Redlock(RedisInstance& instance, RandomBufferInterface& randomBuffer) :
+		_randomBuffer(randomBuffer),
+		_instance(instance),
+		_unlockScript("\
+if redis.call(\"GET\",KEYS[1]) == ARGV[1] then \
+  return redis.call(\"del\",KEYS[1]) \
+else \
+  return 0 \
+end \
+"),
+		_extendLockScript("\
+if redis.call(\"GET\",KEYS[1]) == ARGV[1] then \
+  return redis.call(\"expire\",KEYS[1],ARGV[2]) \
+else \
+  return 0 \
+end \
+"),
+		_unlockSHA1(loadScript(_unlockScript)),
+		_extendLockSHA1(loadScript(_extendLockScript))
+	{
+	}
+
+	// Only locks if no lock for the supplied key exists.
+	// The lock will stay valid until unlock() is called,
+	// or until the ttl period expired.
+	bool lock(const std::string& key, const std::chrono::milliseconds& ttl) {
+		const auto randomString = _randomBuffer.getUpdatedString();
+		bool result = _instance.set(key, randomString, ttl, UpdateType::NOT_EXIST);
+		if (result) {
+			_randomNumberMap[key] = randomString;
+		}
+		return result;
+	}
+
+	// An existing lock could be extended by ttl milliseconds.
+	// This is handy for safely holding onto a lock, by calling
+	// extend_lock periodically within the ttl period. It the
+	// original lock expired, before calling extend_lock(),
+	// the lock will not be extended.
+	bool extend_lock(const std::string& key, const std::chrono::milliseconds& ttl);
+
+	// If a lock exists and this instance is the owner of the lock,
+	// the lock will be released.
+	void unlock(const std::string& key);
+
+private:
+	void checkAndLoad(Redis& instance, const std::string& sha1, const std::string& scriptString);
+	std::string loadScript(const std::string& script);
+
+	RandomBufferInterface& _randomBuffer;
+	RedisInstance& _instance;
+	const std::string _unlockScript;
+	const std::string _extendLockScript;
+	const std::string _unlockSHA1;
+	const std::string _extendLockSHA1;
+	std::map<std::string, std::string> _randomNumberMap;
+};
+
+} // namespace sw
+
+} // namespace redis
+
+#endif // end REDISPLUSPLUS_REDLOCK_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,7 +17,16 @@ find_path(HIREDIS_HEADER hiredis)
 target_include_directories(${PROJECT_NAME} PUBLIC ${HIREDIS_HEADER})
 
 find_library(HIREDIS_STATIC_LIB libhiredis.a)
-target_link_libraries(${PROJECT_NAME} ${HIREDIS_STATIC_LIB})
+
+find_package (OpenSSL)
+
+if (OPENSSL_FOUND)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC -DUSE_OPENSSL)
+  include_directories(${OPENSSL_INCLUDE_DIR})
+  target_link_libraries(${PROJECT_NAME} ${HIREDIS_STATIC_LIB} ${OPENSSL_CRYPTO_LIBRARY})
+else (OPENSSL_FOUND)
+  target_link_libraries(${PROJECT_NAME} ${HIREDIS_STATIC_LIB})
+endif (OPENSSL_FOUND)
 
 # redis++ dependency
 target_include_directories(${PROJECT_NAME} PUBLIC ../src)
@@ -30,4 +39,8 @@ ENDIF(CMAKE_SYSTEM_NAME MATCHES "(Solaris|SunOS)" )
 
 find_package(Threads REQUIRED)
 
-target_link_libraries(${PROJECT_NAME} ${REDIS_PLUS_PLUS_LIB} ${CMAKE_THREAD_LIBS_INIT})
+if (OPENSSL_FOUND)
+  target_link_libraries(${PROJECT_NAME} ${REDIS_PLUS_PLUS_LIB} ${CMAKE_THREAD_LIBS_INIT} ${OPENSSL_CRYPTO_LIBRARY})
+else (OPENSSL_FOUND)
+  target_link_libraries(${PROJECT_NAME} ${REDIS_PLUS_PLUS_LIB} ${CMAKE_THREAD_LIBS_INIT})
+endif (OPENSSL_FOUND)

--- a/test/src/sw/redis++/redlock_test.h
+++ b/test/src/sw/redis++/redlock_test.h
@@ -1,11 +1,11 @@
 /**************************************************************************
-   Copyright (c) 2017 sewenew
+   Copyright (c) 2019
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+	   http://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,13 +14,34 @@
    limitations under the License.
  *************************************************************************/
 
-#ifndef SEWENEW_REDISPLUSPLUS_REDISPLUSPLUS_H
-#define SEWENEW_REDISPLUSPLUS_REDISPLUSPLUS_H
+#ifndef REDISPLUSPLUS_TEST_REDLOCK_TEST_H
+#define REDISPLUSPLUS_TEST_REDLOCK_TEST_H
 
-#include "redis.h"
-#include "redis_cluster.h"
-#include "queued_redis.h"
-#include "sentinel.h"
-#include "redlock.hpp"
+#include <sw/redis++/redis++.h>
 
-#endif // end SEWENEW_REDISPLUSPLUS_REDISPLUSPLUS_H
+namespace sw {
+
+namespace redis {
+
+namespace test {
+
+template <typename RedisInstance>
+class RedlockTest {
+public:
+	explicit RedlockTest(RedisInstance &instance) : _redis(instance) {}
+
+	void run();
+
+private:
+	RedisInstance &_redis;
+};
+
+} // namespace test
+
+} // namespace redis
+
+} // namespace sw
+
+#include "redlock_test.hpp"
+
+#endif // end REDISPLUSPLUS_TEST_REDLOCK_TEST_H

--- a/test/src/sw/redis++/redlock_test.hpp
+++ b/test/src/sw/redis++/redlock_test.hpp
@@ -170,8 +170,9 @@ void RedlockTest<RedisInstance>::run() {
 		usleep(ttl.count() * 1000 * 2 / 3);
 		// Now we have 1/3 of the ttl left, so we extend it by ttl.
 		if (redLock.extend_lock(lockKey, ttl)) {
-			// We'll sleep ttl + 100 millis and see if the lock is gone.
-			usleep((ttl.count() * 1000) + 100);
+			// We'll sleep ttl + 2 millis and see if the lock is gone.
+			// 1 ms for extend_lock() and 1 ms for Redis expire latency.
+			usleep((ttl.count() + 2) * 1000);
 			// Locking it should not fail.
 			if (redLock.lock(lockKey, ttl)) {
 				redLock.unlock(lockKey);

--- a/test/src/sw/redis++/redlock_test.hpp
+++ b/test/src/sw/redis++/redlock_test.hpp
@@ -97,7 +97,7 @@ void RedlockTest<RedisInstance>::run() {
 	Redlock<RedisInstance> redLock(_redis, randomBuffer);
 
 	const auto lockKey = test_key("some_random_key_name.lock");
-	const std::chrono::milliseconds ttl(100);
+	const std::chrono::milliseconds ttl(200);
 
 	// 1. Test if we can obtain a lock.
 	if (redLock.lock(lockKey, ttl)) {

--- a/test/src/sw/redis++/redlock_test.hpp
+++ b/test/src/sw/redis++/redlock_test.hpp
@@ -189,6 +189,26 @@ void RedlockTest<RedisInstance>::run() {
 	else {
 		REDIS_ASSERT(0, "unable to obtain a lock.");
 	}
+
+	// 6. Test if ~Redlock() releases all the locked keys.
+	{
+		Redlock<RedisInstance> tmpRedLock(_redis, randomBuffer);
+		if (tmpRedLock.lock(lockKey, ttl)) {
+			// Don't unlock, as we're testing the destructor's unlock.
+		}
+		else {
+			REDIS_ASSERT(0, "unable to obtain a lock.");
+		}
+	}
+	// We destructed within TTL, so we should be able to lock,
+	// if the destructor unlocked the key.
+	if (redLock.lock(lockKey, ttl)) {
+		redLock.unlock(lockKey);
+	}
+	else {
+		redLock.unlock(lockKey);
+		REDIS_ASSERT(0, "The Redlock destructor failed to unlock.");
+	}
 }
 
 } // namespace test

--- a/test/src/sw/redis++/redlock_test.hpp
+++ b/test/src/sw/redis++/redlock_test.hpp
@@ -1,0 +1,174 @@
+/**************************************************************************
+   Copyright (c) 2019
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+	   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ *************************************************************************/
+
+#ifndef REDISPLUSPLUS_REDLOCK_CMDS_TEST_HPP
+#define REDISPLUSPLUS_REDLOCK_CMDS_TEST_HPP
+
+#include <sw/redis++/redis++.h>
+
+namespace sw {
+
+namespace redis {
+
+namespace test {
+
+#ifdef USE_OPENSSL
+#include <openssl/rc4.h>
+
+template <int N = 20>
+class RandomBuffer : public sw::redis::RandomBufferInterface
+{
+public:
+	RandomBuffer() :
+		_inIdx(0),
+		_outIdx(1)
+	{
+		int randomNum = std::rand();
+		const auto RN_SIZE = sizeof(randomNum);
+		for (size_t i=0; i<N; i+=RN_SIZE) {
+			memcpy(&_data[_inIdx][i], &randomNum, (N - i >= RN_SIZE) ? RN_SIZE : N - i);
+			randomNum = std::rand();
+		}
+		RC4_set_key(&_key, N, _data[0]);
+	}
+
+	std::string getUpdatedString() {
+		RC4(&_key, N, _data[_inIdx], _data[_outIdx]);
+		// Swap the in and out buffers.
+		if (_inIdx == 0) {
+			_inIdx = 1;
+			_outIdx = 0;
+		}
+		else {
+			_inIdx = 0;
+			_outIdx = 1;
+		}
+		return std::string((char*)(_data[_inIdx]), N);
+	}
+
+private:
+	uint8_t _inIdx;
+	uint8_t _outIdx;
+	uint8_t _data[2][N];
+	RC4_KEY _key;
+};
+
+#else // !USE_OPENSSL
+
+template <int N = 20>
+class RandomBuffer : public sw::redis::RandomBufferInterface
+{
+public:
+	// The following is dead-slow.
+	// Only use this for testing, if no openssl lib is installed.
+	std::string getUpdatedString() {
+		int randomNum = std::rand();
+		const auto RN_SIZE = sizeof(randomNum);
+		for (size_t i=0; i<N; i+=RN_SIZE) {
+			memcpy(&_data[i], &randomNum, (N - i >= RN_SIZE) ? RN_SIZE : N - i);
+			randomNum = std::rand();
+		}
+		return std::string((char*)_data, N);
+	}
+
+private:
+	uint8_t _data[N];
+};
+
+#endif // USE_OPENSSL
+
+template <typename RedisInstance>
+void RedlockTest<RedisInstance>::run() {
+	std::srand(std::time(nullptr));
+	RandomBuffer<> randomBuffer;
+	Redlock<RedisInstance> redLock(_redis, randomBuffer);
+
+	const auto lockKey = test_key("some_random_key_name.lock");
+	const std::chrono::milliseconds ttl(100);
+
+	// 1. Test if we can obtain a lock.
+	if (redLock.lock(lockKey, ttl)) {
+		redLock.unlock(lockKey);
+	}
+	else {
+		REDIS_ASSERT(0, "unable to obtain a lock.");
+	}
+
+	// 2. Test if the lock fails if we try to lock a key, after
+	//    a lock was already obtained.
+	if (redLock.lock(lockKey, ttl)) {
+		if (redLock.lock(lockKey, ttl)) {
+			REDIS_ASSERT(0, "managed to get lock from redlock, while redlock was locked.");
+		}
+		redLock.unlock(lockKey);
+	}
+	else {
+		REDIS_ASSERT(0, "unable to obtain a lock.");
+	}
+
+	// 3. Test if the lock succeeds if we're trying to obtain a lock,
+	//    after the TTL expired of the original lock, when the original
+	//    lock was not unlocked.
+	if (redLock.lock(lockKey, ttl)) {
+		// Sleep twice the TTL duration.
+		usleep(2 * ttl.count() * 1000);
+		if (redLock.lock(lockKey, ttl)) {
+			redLock.unlock(lockKey);
+		}
+		else {
+			redLock.unlock(lockKey);
+			REDIS_ASSERT(0, "redlock lock was not automatically released after TTL expired.");
+		}
+	}
+	else {
+		REDIS_ASSERT(0, "unable to obtain a lock.");
+	}
+
+	// 4. Test if the lock is extendable.
+	if (redLock.lock(lockKey, ttl)) {
+		// We'll sleep 2/3 of the ttl.
+		usleep(ttl.count() * 1000 * 2 / 3);
+		// Now we have 1/3 of the ttl left, so we extend it by ttl.
+		if (redLock.extend_lock(lockKey, ttl)) {
+			// We'll sleep 2/3 of the ttl.
+			usleep(ttl.count() * 1000 * 2 / 3);
+			// Now we have 1/3 of the ttl left, if the extend_lock worked,
+			// so locking should fail.
+			if (redLock.lock(lockKey, ttl)) {
+				redLock.unlock(lockKey);
+				REDIS_ASSERT(0, "redlock extend_lock failed to extend the TTL.");
+			}
+			else {
+				redLock.unlock(lockKey);
+			}
+		}
+		else {
+			redLock.unlock(lockKey);
+			REDIS_ASSERT(0, "redlock extend_lock failed, although the lock exists.");
+		}
+	}
+	else {
+		REDIS_ASSERT(0, "unable to obtain a lock.");
+	}
+}
+
+} // namespace test
+
+} // namespace redis
+
+} // namespace sw
+
+#endif // REDISPLUSPLUS_REDLOCK_CMDS_TEST_HPP

--- a/test/src/sw/redis++/test_main.cpp
+++ b/test/src/sw/redis++/test_main.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <sw/redis++/redis++.h>
 #include "sanity_test.h"
+#include "redlock_test.h"
 #include "connection_cmds_test.h"
 #include "keys_cmds_test.h"
 #include "string_cmds_test.h"
@@ -218,6 +219,11 @@ void run_test(const sw::redis::ConnectionOptions &opts) {
     connection_test.run();
 
     std::cout << "Pass connection commands tests" << std::endl;
+
+    sw::redis::test::RedlockTest<RedisInstance> redlock_test(instance);
+    redlock_test.run();
+
+    std::cout << "Pass redlock tests" << std::endl;
 
     sw::redis::test::KeysCmdTest<RedisInstance> keys_test(instance);
     keys_test.run();


### PR DESCRIPTION
The definition of the Redlock (template) class is available in
src/sw/redis++/redlock.*

The tests are implemented in test/src/sw/redis++/redlock_test.h*

The implementation is meant for a single Redis instance or for a
single clustered Redis instance. The locking of multiple instances is
not supported, but could be added.