### PR TITLE
Added C++17 compile time switch for using std::optional<T> and std::string_view.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,33 @@ else()
     cmake_minimum_required(VERSION 2.8.0)
 endif()
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -W -Werror -fPIC")
+# Check C++ compiler support
+message(STATUS "Checking compiler support...")
+
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG(-std=c++17 HAVE_FLAG_STD_CXX17)
+if(HAVE_FLAG_STD_CXX17)
+    message(STATUS "Supported C++ standard: C++17")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -DM_CPP17_AVAILABLE")
+elseif()
+    CHECK_CXX_COMPILER_FLAG(-std=c++1z HAVE_FLAG_STD_CXX1Z)
+    if(HAVE_FLAG_STD_CXX1Z)
+        message(STATUS "Supported C++ standard: C++17 [C++1z]")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1z -DM_CPP17_AVAILABLE")
+   else()
+        CHECK_CXX_COMPILER_FLAG(-std=c++11 HAVE_FLAG_STD_CXX11)
+        if(HAVE_FLAG_STD_CXX11)
+            message(STATUS "Supported C++ standard: C++11")
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+        else()
+            message(FATAL_ERROR "C++11 is NOT supported!")
+        endif()
+    endif()
+endif()
+
+# Set compiler flags
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -W -Werror -fPIC")
+message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 

--- a/src/sw/redis++/utils.h
+++ b/src/sw/redis++/utils.h
@@ -21,12 +21,28 @@
 #include <string>
 #include <type_traits>
 
+// If C++17 is supported, include standard headers std::optional and std::string_view.
+#ifdef M_CPP17_AVAILABLE
+#include <optional>
+#include <string_view>
+#endif
+
 namespace sw {
 
 namespace redis {
 
-// By now, not all compilers support std::string_view,
-// so we make our own implementation.
+// If C++17 is supported, use aliases of std::optional<T> and std::string_view.
+#ifdef M_CPP17_AVAILABLE
+
+template <typename T>
+using Optional = std::optional<T>;
+
+using StringView = std::string_view;
+
+#else
+
+// If C++17 is not supported, use our custom implementations of C++17 features
+// std::string_view and std::optional<T>.
 class StringView {
 public:
     constexpr StringView() noexcept = default;
@@ -101,6 +117,8 @@ public:
 private:
     std::pair<bool, T> _value;
 };
+
+#endif // end M_CPP17_AVAILABLE
 
 using OptionalString = Optional<std::string>;
 
@@ -262,8 +280,8 @@ struct IsAssociativeContainer
 
 uint16_t crc16(const char *buf, int len);
 
-}
+} // redis
 
-}
+} // sw
 
 #endif // end SEWENEW_REDISPLUSPLUS_UTILS_H


### PR DESCRIPTION
Added CMake compiler support checks for C++17.
Added C++17 macro for using in source to switch between standard or custom support for `std::optional<T>` and `std::string_view`.

Tested with GCC 7.4.0 on Ubuntu 18.04.