### PR TITLE
Introduced uri optional arguments

### DIFF
--- a/src/sw/redis++/connection.h
+++ b/src/sw/redis++/connection.h
@@ -80,6 +80,14 @@ private:
     auto _split_path(const std::string &path) const
         -> std::tuple<std::string, int>;
 
+    template <typename T>
+    void _set_optional_key(const std::string &options_uri, const std::string &key, T &field) const;
+
+    std::optional<std::string> _extract_string_option(const std::string &options_uri, const std::string &key) const;
+
+    auto _split_additional_opts(const std::string &uri) const
+        -> std::tuple<bool, std::chrono::milliseconds, std::chrono::milliseconds>;
+
     void _set_auth_opts(const std::string &auth, ConnectionOptions &opts) const;
 
     void _set_tcp_opts(const std::string &path, ConnectionOptions &opts) const;


### PR DESCRIPTION
Hi @sewenew ,
I manage to extract optional arguments from the URI. I tried to follow your code-style, but if I miss something, sorry for that!
Here a simple function to print the resulted connection:
```
 sw::redis::ConnectionOptions opts("tcp://username:password@127.0.0.1:6379/12?socket_timeout=3000&keep_alive=true&connect_timeout=2000");
    std::cout << "OPTS:\n\tTCP: " << (opts.type == redis::ConnectionType::TCP ? "YES" : "NO") << "\n\thost: " << opts.host << "\n\tport: " << opts.port;
    std::cout << "\n\tpath: " << opts.path << "\n\tuser: " << opts.user << "\n\tpassword: " << opts.password << "\n\tdb: " << opts.db;
    std::cout << "\n\tkeep_alive: " << opts.keep_alive << "\n\tconnection_timeout: " << opts.connect_timeout.count() << "\n\tsocket_timeout: " << opts.socket_timeout.count();
    std::cout << std::endl;
```
If all seems good to you, maybe write some tests could be a good solution.
Let me know what do you think about it!

