### PR TITLE
Added stream test with concurrent xadd and xread showing issue in to_array()

### DIFF
--- a/test/src/sw/redis++/test_main.cpp
+++ b/test/src/sw/redis++/test_main.cpp
@@ -212,7 +212,7 @@ int getopt(int argc, char **argv, const char *optstring) {
 
 void print_help() {
     std::cerr << "Usage: test_redis++ -h host -p port"
-        << " -n cluster_node -c cluster_port [-a auth] [-b]\n\n";
+        << " -n cluster_node -c cluster_port [-a auth] [-b] [-m]\n\n";
     std::cerr << "See https://github.com/sewenew/redis-plus-plus#run-tests-optional"
         << " for details on how to run test" << std::endl;
 }

--- a/test/src/sw/redis++/threads_test.h
+++ b/test/src/sw/redis++/threads_test.h
@@ -33,6 +33,8 @@ public:
     void run();
 
 private:
+    void _test_multithreads_stream_read_and_write(RedisInstance redis, int threads_num, int times);
+
     void _test_multithreads(RedisInstance redis, int threads_num, int times);
 
     void _test_timeout();


### PR DESCRIPTION
Hi,

In my application I ran into a concurrency issue.
I narrowed it down to an issue in redis-plus-plus.
I've added a multi-threaded test with xadd and xread that shows the issue. It appears to be somewhere in the to_array() template code. I tried debugging it but gave up after going through 7 layers of template code with gdb, as I'm not familiar with this code.

Could you help debug and fix this issue? You can reproduce the issue by just running the test binary with option -m.

P.S. I also added a missed option,[-m], to the command help text.