### PR TITLE
Update reply.cpp

### DIFF
--- a/src/sw/redis++/reply.cpp
+++ b/src/sw/redis++/reply.cpp
@@ -39,6 +39,10 @@ std::string to_status(redisReply &reply) {
 }
 
 std::string parse(ParseTag<std::string>, redisReply &reply) {
+    if (reply::is_nil(reply)) {
+        return "";
+    }
+
     if (!reply::is_string(reply) && !reply::is_status(reply)) {
         throw ProtoError("Expect STRING reply");
     }


### PR DESCRIPTION
If a hash has fields that don't exist, the hmget command throws an exception when I want to get other fields that do exist