### PR TITLE
Keep connection on timeout

### DIFF
--- a/src/sw/redis++/errors.cpp
+++ b/src/sw/redis++/errors.cpp
@@ -38,7 +38,7 @@ namespace sw {
 
 namespace redis {
 
-void throw_error(redisContext &context, const std::string &err_info) {
+void throw_error(redisContext &context, const std::string &err_info, bool clear_on_timeout) {
     auto err_code = context.err;
     const auto *err_str = context.errstr;
     if (err_str == nullptr) {
@@ -50,6 +50,9 @@ void throw_error(redisContext &context, const std::string &err_info) {
     switch (err_code) {
     case REDIS_ERR_IO:
         if (errno == EAGAIN || errno == EWOULDBLOCK || errno == ETIMEDOUT) {
+            if (clear_on_timeout) {
+                context.err = 0;
+            }
             throw TimeoutError(err_msg);
         } else {
             throw IoError(err_msg);

--- a/src/sw/redis++/errors.h
+++ b/src/sw/redis++/errors.h
@@ -148,7 +148,7 @@ class MovedError;
 
 class AskError;
 
-void throw_error(redisContext &context, const std::string &err_info);
+void throw_error(redisContext &context, const std::string &err_info, bool clear_on_timeout);
 
 void throw_error(const redisReply &reply);
 

--- a/src/sw/redis++/pipeline.cpp
+++ b/src/sw/redis++/pipeline.cpp
@@ -23,7 +23,7 @@ namespace redis {
 std::vector<ReplyUPtr> PipelineImpl::exec(Connection &connection, std::size_t cmd_num) {
     std::vector<ReplyUPtr> replies;
     while (cmd_num > 0) {
-        replies.push_back(connection.recv());
+        replies.push_back(connection.recv(false));
         --cmd_num;
     }
 

--- a/src/sw/redis++/redis.hpp
+++ b/src/sw/redis++/redis.hpp
@@ -1268,7 +1268,7 @@ ReplyUPtr Redis::_command(Connection &connection, Cmd cmd, Args &&...args) {
 
     cmd(connection, std::forward<Args>(args)...);
 
-    auto reply = connection.recv();
+    auto reply = connection.recv(true);
 
     return reply;
 }

--- a/src/sw/redis++/redis_cluster.cpp
+++ b/src/sw/redis++/redis_cluster.cpp
@@ -790,7 +790,7 @@ void RedisCluster::_asking(Connection &connection) {
     // Send ASKING command.
     connection.send("ASKING");
 
-    auto reply = connection.recv();
+    auto reply = connection.recv(true);
 
     assert(reply);
 

--- a/src/sw/redis++/redis_cluster.hpp
+++ b/src/sw/redis++/redis_cluster.hpp
@@ -1278,7 +1278,7 @@ ReplyUPtr RedisCluster::_command(Cmd cmd, Connection &connection, Args &&...args
 
     cmd(connection, std::forward<Args>(args)...);
 
-    return connection.recv();
+    return connection.recv(true);
 }
 
 template <typename Cmd, typename ...Args>
@@ -1290,6 +1290,8 @@ ReplyUPtr RedisCluster::_command(Cmd cmd, const StringView &key, Args &&...args)
             SafeConnection safe_connection(*pool);
 
             return _command(cmd, safe_connection.connection(), std::forward<Args>(args)...);
+        } catch (const TimeoutError &err) {
+            throw;
         } catch (const IoError &err) {
             // When master is down, one of its replicas will be promoted to be the new master.
             // If we try to send command to the old master, we'll get an *IoError*.

--- a/src/sw/redis++/sentinel.cpp
+++ b/src/sw/redis++/sentinel.cpp
@@ -205,7 +205,7 @@ Connection Sentinel::slave(const std::string &master_name, const ConnectionOptio
 Optional<Node> Sentinel::_get_master_addr_by_name(Connection &connection, const StringView &name) {
     connection.send("SENTINEL GET-MASTER-ADDR-BY-NAME %b", name.data(), name.size());
 
-    auto reply = connection.recv();
+    auto reply = connection.recv(true);
 
     assert(reply);
 
@@ -229,7 +229,7 @@ std::vector<Node> Sentinel::_get_slave_addr_by_name(Connection &connection,
     try {
         connection.send("SENTINEL SLAVES %b", name.data(), name.size());
 
-        auto reply = connection.recv();
+        auto reply = connection.recv(true);
 
         assert(reply);
 
@@ -287,7 +287,7 @@ Connection Sentinel::_connect_redis(const Node &node, ConnectionOptions opts) {
 
 Role Sentinel::_get_role(Connection &connection) {
     connection.send("INFO REPLICATION");
-    auto reply = connection.recv();
+    auto reply = connection.recv(true);
 
     assert(reply);
     auto info = reply::parse<std::string>(*reply);

--- a/src/sw/redis++/shards_pool.cpp
+++ b/src/sw/redis++/shards_pool.cpp
@@ -171,7 +171,7 @@ Shards ShardsPool::_cluster_slots(Connection &connection) const {
 ReplyUPtr ShardsPool::_cluster_slots_command(Connection &connection) const {
     connection.send("CLUSTER SLOTS");
 
-    return connection.recv();
+    return connection.recv(true);
 }
 
 Shards ShardsPool::_parse_reply(redisReply &reply) const {

--- a/src/sw/redis++/subscriber.cpp
+++ b/src/sw/redis++/subscriber.cpp
@@ -77,12 +77,7 @@ void Subscriber::consume() {
     _check_connection();
 
     ReplyUPtr reply;
-    try {
-        reply = _connection.recv();
-    } catch (const TimeoutError &) {
-        _connection.reset();
-        throw;
-    }
+    reply = _connection.recv(false);
 
     assert(reply);
 

--- a/src/sw/redis++/transaction.cpp
+++ b/src/sw/redis++/transaction.cpp
@@ -41,7 +41,7 @@ void TransactionImpl::_open_transaction(Connection &connection) {
     assert(!_in_transaction);
 
     cmd::multi(connection);
-    auto reply = connection.recv();
+    auto reply = connection.recv(false);
     auto status = reply::to_status(*reply);
     if (status != "OK") {
         throw Error("Failed to open transaction: " + status);
@@ -59,7 +59,7 @@ void TransactionImpl::_close_transaction() {
 }
 
 void TransactionImpl::_get_queued_reply(Connection &connection) {
-    auto reply = connection.recv();
+    auto reply = connection.recv(false);
     auto status = reply::to_status(*reply);
     if (status != "QUEUED") {
         throw Error("Invalid QUEUED reply: " + status);
@@ -80,7 +80,7 @@ void TransactionImpl::_get_queued_replies(Connection &connection, std::size_t cm
 std::vector<ReplyUPtr> TransactionImpl::_exec(Connection &connection) {
     cmd::exec(connection);
 
-    auto reply = connection.recv();
+    auto reply = connection.recv(false);
 
     if (reply::is_nil(*reply)) {
         // Execution has been aborted, i.e. watched key has been modified.
@@ -114,7 +114,7 @@ std::vector<ReplyUPtr> TransactionImpl::_exec(Connection &connection) {
 
 void TransactionImpl::_discard(Connection &connection) {
     cmd::discard(connection);
-    auto reply = connection.recv();
+    auto reply = connection.recv(false);
     reply::parse<void>(*reply);
 }
 

--- a/test/src/sw/redis++/timeout_test.h
+++ b/test/src/sw/redis++/timeout_test.h
@@ -1,0 +1,46 @@
+/**************************************************************************
+   Copyright (c) 2021 Qlik
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ *************************************************************************/
+
+#ifndef SEWENEW_REDISPLUSPLUS_TEST_TIMEOUT_TEST_H
+#define SEWENEW_REDISPLUSPLUS_TEST_TIMEOUT_TEST_H
+
+#include <sw/redis++/redis++.h>
+
+namespace sw {
+
+namespace redis {
+
+namespace test {
+
+template <typename RedisInstance>
+class TimeoutTest {
+public:
+    TimeoutTest(RedisInstance &instance);
+
+    void run();
+
+private:
+
+    RedisInstance &_redis;
+};
+
+}
+}
+}
+
+#include "timeout_test.hpp"
+
+#endif // end SEWENEW_REDISPLUSPLUS_TEST_TIMEOUT_TEST_H

--- a/test/src/sw/redis++/timeout_test.hpp
+++ b/test/src/sw/redis++/timeout_test.hpp
@@ -1,0 +1,62 @@
+/**************************************************************************
+   Copyright (c) 2021 Qlik
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ *************************************************************************/
+
+#ifndef SEWENEW_REDISPLUSPLUS_TEST_TIMEOUT_TEST_HPP
+#define SEWENEW_REDISPLUSPLUS_TEST_TIMEOUT_TEST_HPP
+
+#include <chrono>
+
+#define KEY "TestKey"
+
+namespace sw {
+
+namespace redis {
+
+namespace test {
+
+template <typename RedisInstance>
+TimeoutTest<RedisInstance>::TimeoutTest(RedisInstance &instance) :_redis(instance) { }
+
+template <typename RedisInstance>
+void TimeoutTest<RedisInstance>::run() {
+    for(int i = 0; i < 100000; i++) {
+        try{
+            _redis.set(KEY, std::to_string(i));
+            OptionalString stringValue = this->_redis.get(KEY);
+            if (!stringValue) {
+                REDIS_ASSERT(false, "Obtained null string reply");
+            }
+            int value = std::stoi(*stringValue);
+            REDIS_ASSERT(value == i, "Obtained wrong value");
+        } catch (const sw::redis::MovedError &e) {
+            REDIS_ASSERT(false, e.what());
+        } catch (const sw::redis::TimeoutError &) {
+            //Ignore
+        }  catch (const sw::redis::Error &e) {
+            REDIS_ASSERT(false, e.what());
+        } catch (std::invalid_argument &e) {
+            REDIS_ASSERT(false, "Wrong type of value obtained");
+        }
+    }
+
+    _redis.del(KEY);
+}
+
+}
+}
+}
+
+#endif // end SEWENEW_REDISPLUSPLUS_TEST_TIMEOUT_TEST_HPP


### PR DESCRIPTION
When reconnect is done due to timeout the output buffer is lost, and it is unknown whether commands sent will or will not reach the server, which can result in lost data. By instead keeping the connection and receiving and ignoring stale messages it is ensured at least that all commands are sent in time.

Timeout test case added in separate commit.
