### PR TITLE
Provide TLS option for connections to Sentinel Nodes

### DIFF
--- a/src/sw/redis++/sentinel.cpp
+++ b/src/sw/redis++/sentinel.cpp
@@ -322,6 +322,7 @@ std::list<ConnectionOptions> Sentinel::_parse_options(const SentinelOptions &opt
         opt.keep_alive = opts.keep_alive;
         opt.connect_timeout = opts.connect_timeout;
         opt.socket_timeout = opts.socket_timeout;
+        opt.tls = opts.tls;
 
         options.push_back(opt);
     }

--- a/src/sw/redis++/sentinel.h
+++ b/src/sw/redis++/sentinel.h
@@ -25,6 +25,7 @@
 #include "connection.h"
 #include "shards.h"
 #include "reply.h"
+#include "tls.h"
 
 namespace sw {
 
@@ -44,6 +45,8 @@ struct SentinelOptions {
     std::chrono::milliseconds retry_interval{100};
 
     std::size_t max_retry = 2;
+
+    tls::TlsOptions tls;
 };
 
 class Sentinel {


### PR DESCRIPTION
Hi, I've tried to use the TLS option to connect to our Redis Sentinel server.
However, I was unable to do so. I dug into the problem and managed to find
out that even though there is support for TLS in redis-plus-plus implemented,
it does not cover Redis Sentinel nodes' connections.

In this PR I added necessary lines of code to cover TLS support for
Redis Sentinel nodes.