### PR TITLE
Added basic support for building a Debian package.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,3 +208,32 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/redis++.pc.in"
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/cmake/redis++.pc"
         DESTINATION "lib/pkgconfig")
+
+option(REDIS_PLUS_PLUS_BUILD_DEBIAN "Build Debian package" OFF)
+
+if (REDIS_PLUS_PLUS_BUILD_DEBIAN)
+    SET(CPACK_GENERATOR "DEB")
+    SET(CPACK_DEBIAN_PACKAGE_GENERATE_SHLIBS "ON")
+
+    if (NOT DEFINED CPACK_DEBIAN_PACKAGE_MAINTAINER)
+        SET(CPACK_DEBIAN_PACKAGE_MAINTAINER "anonymous")
+    endif()
+    if (NOT DEFINED CPACK_PACKAGE_NAME)
+        SET(CPACK_PACKAGE_NAME "libredis++-dev")
+    endif()
+    if (NOT DEFINED CPACK_DEBIAN_PACKAGE_DEPENDS)
+        SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libstdc++6, libhiredis-dev")
+    endif()
+
+    EXECUTE_PROCESS(COMMAND bash -c "dpkg --print-architecture" OUTPUT_VARIABLE CPACK_DEBIAN_PACKAGE_ARCHITECTURE)
+    string(REGEX REPLACE "\n$" "" CPACK_DEBIAN_PACKAGE_ARCHITECTURE "${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}")
+    SET(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}_${PROJECT_VERSION}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}")
+
+    SET(CPACK_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
+    SET(CPACK_DEBIAN_PACKAGE_SOURCE "https://github.com/sewenew/redis-plus-plus")
+    set(CPACK_PACKAGE_DESCRIPTION "A pure C++ client for Redis, based on hiredis.")
+
+    message(STATUS "Debian package name: ${CPACK_PACKAGE_FILE_NAME}.deb")
+
+    INCLUDE(CPack)
+endif()

--- a/README.md
+++ b/README.md
@@ -190,6 +190,26 @@ Then you can build it the instructions (links) mentioned above. If you're buildi
 
 **NOTE**: `REDIS_PLUS_PLUS_CXX_STANDARD` is not supported on Windows so far, and TLS/SSL support has not been tested on Windows yet.
 
+##### Building a redis-plus-plus Debian Package (Optional)
+
+Basic support for building a GNU/Debian package is supplied with the use of cmake.
+In order to enable this feature, the `REDIS_PLUS_PLUS_BUILD_DEBIAN` should be set to `ON`.
+The following example shows how this can be done:
+
+```
+mkdir build; cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DREDIS_PLUS_PLUS_BUILD_DEBIAN=ON -DREDIS_PLUS_PLUS_CXX_STANDARD=14 ..
+cpack -G DEB
+```
+
+The install prefix may be modified as follows:
+
+```
+mkdir build; cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DREDIS_PLUS_PLUS_BUILD_DEBIAN=ON -DREDIS_PLUS_PLUS_CXX_STANDARD=14 -DCMAKE_INSTALL_PREFIX=/usr ..
+cpack -G DEB
+```
+
 ### Run Tests (Optional)
 
 *redis-plus-plus* has been fully tested with the following compilers:
@@ -201,6 +221,7 @@ gcc version 6.5.0 20181026 (Ubuntu 6.5.0-2ubuntu1~18.04)
 gcc version 7.4.0 (Ubuntu 7.4.0-1ubuntu1~18.04.1)
 gcc version 8.3.0 (Ubuntu 8.3.0-6ubuntu1~18.04.1)
 gcc version 9.2.1 20191008 (Ubuntu 9.2.1-9ubuntu2)
+gcc version 10.2.1 20210110 (Debian 10.2.1-6)
 clang version 3.9.1-19ubuntu1 (tags/RELEASE_391/rc2)
 clang version 4.0.1-10 (tags/RELEASE_401/final)
 clang version 5.0.1-4 (tags/RELEASE_501/final)


### PR DESCRIPTION
The feature is disabled by default, but setting the
REDIS_PLUS_PLUS_BUILD_DEBIAN variable to ON, will do the trick.