### PR TITLE
Fixed pipeline bug concerning XRANGE and XREVRANGE when used with COUNT.

### DIFF
--- a/src/sw/redis++/queued_redis.h
+++ b/src/sw/redis++/queued_redis.h
@@ -1718,7 +1718,7 @@ public:
                         const StringView &start,
                         const StringView &end,
                         long long count) {
-        return command(cmd::xrange, key, start, end, count);
+        return command(cmd::xrange_count, key, start, end, count);
     }
 
     QueuedRedis& xread(const StringView &key, const StringView &id, long long count) {
@@ -1920,7 +1920,7 @@ public:
                             const StringView &end,
                             const StringView &start,
                             long long count) {
-        return command(cmd::xrevrange, key, end, start, count);
+        return command(cmd::xrevrange_count, key, end, start, count);
     }
 
     QueuedRedis& xtrim(const StringView &key, long long count, bool approx = true) {

--- a/test/src/sw/redis++/pipeline_transaction_test.h
+++ b/test/src/sw/redis++/pipeline_transaction_test.h
@@ -39,6 +39,8 @@ private:
 
     void _test_pipeline(const StringView &key, Pipeline &pipe);
 
+    void _test_pipeline_streams(const StringView &key, Pipeline &pipe);
+
     void _test_transaction(const StringView &key, Transaction &tx);
 
     void _test_watch();


### PR DESCRIPTION
The command mapping for XRANGE and XREVRANGE in queued_redis.h was
wrong for calls that used a COUNT number.

This patch includes a fix for the above, as well as a new test case for
stream-pipeline testing.