### PR TITLE
Made it possible to run test/test_redis++ in parallel.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 
 script:
   - mkdir compile && cd compile && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=$TRAVIS_BUILD_DIR/install .. && make -j2 && cd ..
-  - ./compile/test/test_redis++ -h 127.0.0.1 -p 6379
+  - ./compile/test/test_redis++ -h 127.0.0.1 -p 6379 -f
 
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -270,6 +270,22 @@ By default, the test program will not test running *redis-plus-plus* in multi-th
 ./compile/test/test_redis++ -h host -p port -a auth -n cluster_node -c cluster_port -m
 ```
 
+By default, the test for "SCRIPT FLUSH" is disabled, as it is simply too dangerous to run by default.
+One can however force the "SCRIPT FLUSH" test to be run, by adding the `-f` option:
+
+```
+./compile/test/test_redis++ -h host -p port -f
+```
+
+By default, the keys being used to test with are in the form `{sw::redis::test}::<key>`.
+The `sw::redis::test`-part can however be overridden, by using the `-d` option.
+This comes in handy when running test_redis++ in parallel, pointing it to the same server.
+```
+./compile/test/test_redis++ -h host -p port -f -d sw::redis::test_a &
+./compile/test/test_redis++ -h host -p port -f -d sw::redis::test_b &
+./compile/test/test_redis++ -h host -p port -f -d sw::redis::test_c &
+```
+
 If all tests have been passed, the test program will print the following message:
 
 ```
@@ -2061,7 +2077,7 @@ You can publish and subscribe messages with `RedisCluster`. The interfaces are e
 
 You can also create `Pipeline` and `Transaction` objects with `RedisCluster`, but the interfaces are different from `Redis`. Since all commands in the pipeline and transaction should be sent to a single node in a single connection, we need to tell `RedisCluster` with which node the pipeline or transaction should be created.
 
-Instead of specifing the node's IP and port, `RedisCluster`'s pipeline and transaction interfaces allow you to specify the node with a *hash tag*. `RedisCluster` will calculate the slot number with the given *hash tag*, and create a pipeline or transaction with the node holding the slot.
+Instead of specifying the node's IP and port, `RedisCluster`'s pipeline and transaction interfaces allow you to specify the node with a *hash tag*. `RedisCluster` will calculate the slot number with the given *hash tag*, and create a pipeline or transaction with the node holding the slot.
 
 ```C++
 Pipeline RedisCluster::pipeline(const StringView &hash_tag, bool new_connection = true);

--- a/test/src/sw/redis++/geo_cmds_test.h
+++ b/test/src/sw/redis++/geo_cmds_test.h
@@ -17,7 +17,7 @@
 #ifndef SEWENEW_REDISPLUSPLUS_TEST_GEO_CMDS_TEST_H
 #define SEWENEW_REDISPLUSPLUS_TEST_GEO_CMDS_TEST_H
 
-#include <sw/redis++/redis++.h>
+#include "test_base.h"
 
 namespace sw {
 
@@ -26,9 +26,10 @@ namespace redis {
 namespace test {
 
 template <typename RedisInstance>
-class GeoCmdTest {
+class GeoCmdTest : public TestBase {
 public:
-    explicit GeoCmdTest(RedisInstance &instance) : _redis(instance) {}
+    explicit GeoCmdTest(RedisInstance &instance, const std::string& db_name)
+        : TestBase(db_name), _redis(instance) {}
 
     void run();
 

--- a/test/src/sw/redis++/hash_cmds_test.h
+++ b/test/src/sw/redis++/hash_cmds_test.h
@@ -17,7 +17,7 @@
 #ifndef SEWENEW_REDISPLUSPLUS_TEST_HASH_CMDS_TEST_H
 #define SEWENEW_REDISPLUSPLUS_TEST_HASH_CMDS_TEST_H
 
-#include <sw/redis++/redis++.h>
+#include "test_base.h"
 
 namespace sw {
 
@@ -26,9 +26,10 @@ namespace redis {
 namespace test {
 
 template <typename RedisInstance>
-class HashCmdTest {
+class HashCmdTest : public TestBase {
 public:
-    explicit HashCmdTest(RedisInstance &instance) : _redis(instance) {}
+    explicit HashCmdTest(RedisInstance &instance, const std::string& db_name)
+        : TestBase(db_name), _redis(instance) {}
 
     void run();
 

--- a/test/src/sw/redis++/hyperloglog_cmds_test.h
+++ b/test/src/sw/redis++/hyperloglog_cmds_test.h
@@ -17,7 +17,7 @@
 #ifndef SEWENEW_REDISPLUSPLUS_TEST_HYPERLOGLOG_CMDS_TEST_H
 #define SEWENEW_REDISPLUSPLUS_TEST_HYPERLOGLOG_CMDS_TEST_H
 
-#include <sw/redis++/redis++.h>
+#include "test_base.h"
 
 namespace sw {
 
@@ -26,9 +26,10 @@ namespace redis {
 namespace test {
 
 template <typename RedisInstance>
-class HyperloglogCmdTest {
+class HyperloglogCmdTest : public TestBase {
 public:
-    explicit HyperloglogCmdTest(RedisInstance &instance) : _redis(instance) {}
+    explicit HyperloglogCmdTest(RedisInstance &instance, const std::string& db_name)
+        : TestBase(db_name), _redis(instance) {}
 
     void run();
 

--- a/test/src/sw/redis++/list_cmds_test.h
+++ b/test/src/sw/redis++/list_cmds_test.h
@@ -17,7 +17,7 @@
 #ifndef SEWENEW_REDISPLUSPLUS_TEST_LIST_CMDS_TEST_H
 #define SEWENEW_REDISPLUSPLUS_TEST_LIST_CMDS_TEST_H
 
-#include <sw/redis++/redis++.h>
+#include "test_base.h"
 
 namespace sw {
 
@@ -26,9 +26,10 @@ namespace redis {
 namespace test {
 
 template <typename RedisInstance>
-class ListCmdTest {
+class ListCmdTest : public TestBase {
 public:
-    explicit ListCmdTest(RedisInstance &instance) : _redis(instance) {}
+    explicit ListCmdTest(RedisInstance &instance, const std::string& db_name)
+        : TestBase(db_name), _redis(instance) {}
 
     void run();
 

--- a/test/src/sw/redis++/pipeline_transaction_test.h
+++ b/test/src/sw/redis++/pipeline_transaction_test.h
@@ -17,7 +17,7 @@
 #ifndef SEWENEW_REDISPLUSPLUS_TEST_PIPELINE_TRANSACTION_TEST_H
 #define SEWENEW_REDISPLUSPLUS_TEST_PIPELINE_TRANSACTION_TEST_H
 
-#include <sw/redis++/redis++.h>
+#include "test_base.h"
 
 namespace sw {
 
@@ -26,9 +26,10 @@ namespace redis {
 namespace test {
 
 template <typename RedisInstance>
-class PipelineTransactionTest {
+class PipelineTransactionTest : public TestBase {
 public:
-    explicit PipelineTransactionTest(RedisInstance &instance) : _redis(instance) {}
+    explicit PipelineTransactionTest(RedisInstance &instance, const std::string& db_name)
+        : TestBase(db_name), _redis(instance) {}
 
     void run();
 

--- a/test/src/sw/redis++/pubsub_test.h
+++ b/test/src/sw/redis++/pubsub_test.h
@@ -17,7 +17,7 @@
 #ifndef SEWENEW_REDISPLUSPLUS_TEST_SUBPUB_TEST_H
 #define SEWENEW_REDISPLUSPLUS_TEST_SUBPUB_TEST_H
 
-#include <sw/redis++/redis++.h>
+#include "test_base.h"
 
 namespace sw {
 
@@ -26,9 +26,10 @@ namespace redis {
 namespace test {
 
 template <typename RedisInstance>
-class PubSubTest {
+class PubSubTest : public TestBase {
 public:
-    explicit PubSubTest(RedisInstance &instance) : _redis(instance) {}
+    explicit PubSubTest(RedisInstance &instance, const std::string& db_name)
+        : TestBase(db_name), _redis(instance) {}
 
     void run();
 

--- a/test/src/sw/redis++/sanity_test.h
+++ b/test/src/sw/redis++/sanity_test.h
@@ -17,7 +17,7 @@
 #ifndef SEWENEW_REDISPLUSPLUS_TEST_SANITY_TEST_H
 #define SEWENEW_REDISPLUSPLUS_TEST_SANITY_TEST_H
 
-#include <sw/redis++/redis++.h>
+#include "test_base.h"
 
 namespace sw {
 
@@ -26,10 +26,10 @@ namespace redis {
 namespace test {
 
 template <typename RedisInstance>
-class SanityTest {
+class SanityTest : public TestBase {
 public:
-    SanityTest(const ConnectionOptions &opts, RedisInstance &instance)
-        : _opts(opts), _redis(instance) {}
+    SanityTest(const ConnectionOptions &opts, RedisInstance &instance, const std::string& db_name)
+        : TestBase(db_name), _opts(opts), _redis(instance) {}
 
     void run();
 

--- a/test/src/sw/redis++/script_cmds_test.h
+++ b/test/src/sw/redis++/script_cmds_test.h
@@ -17,7 +17,7 @@
 #ifndef SEWENEW_REDISPLUSPLUS_TEST_SCRIPT_CMDS_TEST_H
 #define SEWENEW_REDISPLUSPLUS_TEST_SCRIPT_CMDS_TEST_H
 
-#include <sw/redis++/redis++.h>
+#include "test_base.h"
 
 namespace sw {
 
@@ -26,9 +26,10 @@ namespace redis {
 namespace test {
 
 template <typename RedisInstance>
-class ScriptCmdTest {
+class ScriptCmdTest : public TestBase {
 public:
-    explicit ScriptCmdTest(RedisInstance &instance) : _redis(instance) {}
+    explicit ScriptCmdTest(RedisInstance &instance, const std::string& db_name, bool do_flush)
+        : TestBase(db_name), _redis(instance), _do_flush(do_flush) {}
 
     void run();
 
@@ -36,6 +37,8 @@ private:
     void _run(Redis &instance);
 
     RedisInstance &_redis;
+
+    const bool _do_flush;
 };
 
 }

--- a/test/src/sw/redis++/set_cmds_test.h
+++ b/test/src/sw/redis++/set_cmds_test.h
@@ -17,7 +17,7 @@
 #ifndef SEWENEW_REDISPLUSPLUS_TEST_SET_CMDS_TEST_H
 #define SEWENEW_REDISPLUSPLUS_TEST_SET_CMDS_TEST_H
 
-#include <sw/redis++/redis++.h>
+#include "test_base.h"
 
 namespace sw {
 
@@ -26,9 +26,10 @@ namespace redis {
 namespace test {
 
 template <typename RedisInstance>
-class SetCmdTest {
+class SetCmdTest : public TestBase {
 public:
-    explicit SetCmdTest(RedisInstance &instance) : _redis(instance) {}
+    explicit SetCmdTest(RedisInstance &instance, const std::string& db_name)
+        : TestBase(db_name), _redis(instance) {}
 
     void run();
 

--- a/test/src/sw/redis++/stream_cmds_test.h
+++ b/test/src/sw/redis++/stream_cmds_test.h
@@ -17,7 +17,7 @@
 #ifndef SEWENEW_REDISPLUSPLUS_TEST_STREAM_CMDS_TEST_H
 #define SEWENEW_REDISPLUSPLUS_TEST_STREAM_CMDS_TEST_H
 
-#include <sw/redis++/redis++.h>
+#include "test_base.h"
 
 namespace sw {
 
@@ -26,9 +26,10 @@ namespace redis {
 namespace test {
 
 template <typename RedisInstance>
-class StreamCmdsTest {
+class StreamCmdsTest : public TestBase {
 public:
-    explicit StreamCmdsTest(RedisInstance &instance) : _redis(instance) {}
+    explicit StreamCmdsTest(RedisInstance &instance, const std::string& db_name)
+        : TestBase(db_name), _redis(instance) {}
 
     void run();
 

--- a/test/src/sw/redis++/string_cmds_test.h
+++ b/test/src/sw/redis++/string_cmds_test.h
@@ -17,7 +17,7 @@
 #ifndef SEWENEW_REDISPLUSPLUS_TEST_STRING_CMDS_TEST_H
 #define SEWENEW_REDISPLUSPLUS_TEST_STRING_CMDS_TEST_H
 
-#include <sw/redis++/redis++.h>
+#include "test_base.h"
 
 namespace sw {
 
@@ -26,9 +26,10 @@ namespace redis {
 namespace test {
 
 template <typename RedisInstance>
-class StringCmdTest {
+class StringCmdTest : public TestBase {
 public:
-    explicit StringCmdTest(RedisInstance &instance) : _redis(instance) {}
+    explicit StringCmdTest(RedisInstance &instance, const std::string& db_name)
+        : TestBase(db_name), _redis(instance) {}
 
     void run();
 

--- a/test/src/sw/redis++/test_base.h
+++ b/test/src/sw/redis++/test_base.h
@@ -1,5 +1,5 @@
 /**************************************************************************
-   Copyright (c) 2017 sewenew
+   Copyright (c) 2021 sewenew, wingunder
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -14,43 +14,30 @@
    limitations under the License.
  *************************************************************************/
 
-#ifndef SEWENEW_REDISPLUSPLUS_TEST_KEYS_CMDS_TEST_H
-#define SEWENEW_REDISPLUSPLUS_TEST_KEYS_CMDS_TEST_H
+#ifndef SEWENEW_REDISPLUSPLUS_TEST_TEST_BASE_H
+#define SEWENEW_REDISPLUSPLUS_TEST_TEST_BASE_H
 
-#include "test_base.h"
+#include <sw/redis++/redis++.h>
 
-namespace sw {
+namespace sw::redis::test {
 
-namespace redis {
-
-namespace test {
-
-template <typename RedisInstance>
-class KeysCmdTest : public TestBase {
+class TestBase {
 public:
-    explicit KeysCmdTest(RedisInstance &instance, const std::string& db_name)
-        : TestBase(db_name), _redis(instance) {}
+    TestBase(const std::string& db_name)
+        : _db_name(db_name) {}
 
-    void run();
+    std::string test_key(const std::string &k) const {
+        // Key prefix with hash tag,
+        // so that we can call multiple-key commands on RedisCluster.
+        return "{" + _db_name + "}::" + k;
+    }
+
+    std::string get_db_name() const { return _db_name; }
 
 private:
-    void _test_key();
-
-    void _test_randomkey(Redis &instance);
-
-    void _test_ttl();
-
-    void _test_scan(Redis &instance);
-
-    RedisInstance &_redis;
+    const std::string& _db_name;
 };
 
 }
 
-}
-
-}
-
-#include "keys_cmds_test.hpp"
-
-#endif // end SEWENEW_REDISPLUSPLUS_TEST_KEYS_CMDS_TEST_H
+#endif

--- a/test/src/sw/redis++/threads_test.h
+++ b/test/src/sw/redis++/threads_test.h
@@ -17,7 +17,7 @@
 #ifndef SEWENEW_REDISPLUSPLUS_TEST_THREADS_TEST_H
 #define SEWENEW_REDISPLUSPLUS_TEST_THREADS_TEST_H
 
-#include <sw/redis++/redis++.h>
+#include "test_base.h"
 
 namespace sw {
 
@@ -26,9 +26,10 @@ namespace redis {
 namespace test {
 
 template <typename RedisInstance>
-class ThreadsTest {
+class ThreadsTest : public TestBase {
 public:
-    explicit ThreadsTest(const ConnectionOptions &opts) : _opts(opts) {}
+    explicit ThreadsTest(const ConnectionOptions &opts, const std::string& db_name)
+        : TestBase(db_name), _opts(opts) {}
 
     void run();
 

--- a/test/src/sw/redis++/utils.h
+++ b/test/src/sw/redis++/utils.h
@@ -40,12 +40,6 @@ inline void redis_assert(bool condition,
     }
 }
 
-inline std::string test_key(const std::string &k) {
-    // Key prefix with hash tag,
-    // so that we can call multiple-key commands on RedisCluster.
-    return "{sw::redis::test}::" + k;
-}
-
 template <typename Test>
 void cluster_specializing_test(Test &test, void (Test::*func)(Redis &instance), Redis &instance) {
     (test.*func)(instance);

--- a/test/src/sw/redis++/zset_cmds_test.h
+++ b/test/src/sw/redis++/zset_cmds_test.h
@@ -17,7 +17,7 @@
 #ifndef SEWENEW_REDISPLUSPLUS_TEST_ZSET_CMDS_TEST_H
 #define SEWENEW_REDISPLUSPLUS_TEST_ZSET_CMDS_TEST_H
 
-#include <sw/redis++/redis++.h>
+#include "test_base.h"
 
 namespace sw {
 
@@ -26,9 +26,10 @@ namespace redis {
 namespace test {
 
 template <typename RedisInstance>
-class ZSetCmdTest {
+class ZSetCmdTest : public TestBase {
 public:
-    explicit ZSetCmdTest(RedisInstance &instance) : _redis(instance) {}
+    explicit ZSetCmdTest(RedisInstance &instance, const std::string& db_name)
+        : TestBase(db_name), _redis(instance) {}
 
     void run();
 


### PR DESCRIPTION
Running more than one test/test_redis++ in parallel on a single Redis
database/node, did not work, as the test key names were always the
same. This patch enables test/test_redis++ to be called with a '-d
db_name' option, for overriding the key's db-name. Furthermore, the
'-f' option was added for enabling the "SCRIPT FLUSH" test.

Note that the "SCRIPT FLUSH" test will now not be run by default. One
has to supply the '-f' option to force this test to be run.

This patch paves the way for some planned Docker images, that would be
able to test builds with different C++ standards, in parallel, using
only a single Redis server.