### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,8 +150,10 @@ if(REDIS_PLUS_PLUS_BUILD_STATIC)
 
     if(REDIS_PLUS_PLUS_BUILD_ASYNC)
         target_include_directories(${STATIC_LIB} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${REDIS_PLUS_PLUS_ASYNC_FUTURE_HEADER}>)
-
         target_include_directories(${STATIC_LIB} PUBLIC $<BUILD_INTERFACE:${REDIS_PLUS_PLUS_ASYNC_LIB_HEADER}>)
+        if(REDIS_PLUS_PLUS_ASYNC_FUTURE STREQUAL "boost")
+            target_include_directories(${STATIC_LIB} SYSTEM PUBLIC $<BUILD_INTERFACE:${Boost_INCLUDE_DIR}>)
+        endif()
     endif()
 
     if (WIN32)
@@ -202,6 +204,9 @@ if(REDIS_PLUS_PLUS_BUILD_SHARED)
         target_include_directories(${SHARED_LIB} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${REDIS_PLUS_PLUS_ASYNC_FUTURE_HEADER}>)
         target_include_directories(${SHARED_LIB} PUBLIC $<BUILD_INTERFACE:${REDIS_PLUS_PLUS_ASYNC_LIB_HEADER}>)
         target_link_libraries(${SHARED_LIB} PUBLIC ${REDIS_PLUS_PLUS_ASYNC_LIB})
+        if(REDIS_PLUS_PLUS_ASYNC_FUTURE STREQUAL "boost")
+            target_include_directories(${SHARED_LIB} SYSTEM PUBLIC $<BUILD_INTERFACE:${Boost_INCLUDE_DIR}>)
+        endif()
     endif()
 
     if(WIN32)


### PR DESCRIPTION
On conan build the boost library is linked from another directory then the linux default ( usr/lib ... ) 
Fixed compile error **fatal error: boost/thread/future.hpp: No such file or directory #include <boost/thread/future.hpp>** on conan build.

Here is an example from CMakeCache.txt

//Path to a file.
Boost_INCLUDE_DIR:PATH=/home/vlad/.conan/data/boost/1.66.0/test/stable/package/41413d93cdddcc6d043afdb11054381baa59a89f/include
