### PR TITLE
Add alias for redis++ lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,7 @@ if(REDIS_PLUS_PLUS_BUILD_STATIC)
     set(STATIC_LIB redis++_static)
 
     add_library(${STATIC_LIB} STATIC ${REDIS_PLUS_PLUS_SOURCES})
+    add_library(redis++::${STATIC_LIB} ALIAS ${STATIC_LIB})
 
     list(APPEND REDIS_PLUS_PLUS_TARGETS ${STATIC_LIB})
 
@@ -184,7 +185,8 @@ if(REDIS_PLUS_PLUS_BUILD_SHARED)
     set(SHARED_LIB redis++)
 
     add_library(${SHARED_LIB} SHARED ${REDIS_PLUS_PLUS_SOURCES})
-
+    add_library(redis++::${SHARED_LIB} ALIAS ${SHARED_LIB})
+    
     list(APPEND REDIS_PLUS_PLUS_TARGETS ${SHARED_LIB})
 
     target_include_directories(${SHARED_LIB} PUBLIC


### PR DESCRIPTION
so when this project is FetchContent-ed, redis++::redis++ can ref to the same lib as when find_package-ed.
e.g
```
find_package(redis++ 1.3.2 QUIET)
if (NOT redis++_FOUND)
    FetchContent_Declare(
            redis++
            GIT_REPOSITORY https://github.com/sewenew/redis-plus-plus.git
            GIT_TAG 1.3.2
    )
    FetchContent_MakeAvailable(redis++)
endif ()
```
#later
target_link_libraries(target redis++::redis++) #redis++::redis++ is always defined and  ref to the same lib