### PR TITLE
Fix erors caused by -Wextra -Wall -Wpedantic -Werror

### DIFF
--- a/test/src/sw/redis++/string_cmds_test.hpp
+++ b/test/src/sw/redis++/string_cmds_test.hpp
@@ -148,7 +148,7 @@ void StringCmdTest<RedisInstance>::_test_bit() {
 
     // dest_key -> 11101111
     v = _redis.get(dest_key);
-    REDIS_ASSERT(v && *v == std::string(1, 0xEF), "failed to test bitop");
+    REDIS_ASSERT(v && *v == std::string(1, '\xEF'), "failed to test bitop");
 }
 
 template <typename RedisInstance>

--- a/test/src/sw/redis++/zset_cmds_test.hpp
+++ b/test/src/sw/redis++/zset_cmds_test.hpp
@@ -134,7 +134,7 @@ void ZSetCmdTest<RedisInstance>::_test_range() {
 
     _redis.zadd(key, s.begin(), s.end());
 
-    REDIS_ASSERT(_redis.zcount(key, UnboundedInterval<double>{}) == s.size(),
+    REDIS_ASSERT(_redis.zcount(key, UnboundedInterval<double>{}) == static_cast<long long int>(s.size()),
                  "failed to test zcount");
 
     std::vector<std::string> members;
@@ -206,7 +206,7 @@ void ZSetCmdTest<RedisInstance>::_test_range() {
             std::back_inserter(members));
     REDIS_ASSERT(members.size() == sReversedKeys.size()-1,
                  "failed to test zrevrangebyscore (size)");
-    for (int i=0; i<members.size(); i++) {
+    for (size_t i=0; i<members.size(); i++) {
         REDIS_ASSERT(members.at(i) == sReversedKeys.at(i+1),
                      "failed to test zrevrangebyscore");
     }


### PR DESCRIPTION
I fixed a couple of compilation problems mainly caused by unstrict implicit type convertions. 