### PR TITLE
Remove static member from subscriber class.

### DIFF
--- a/src/sw/redis++/subscriber.h
+++ b/src/sw/redis++/subscriber.h
@@ -142,6 +142,7 @@ private:
     explicit Subscriber(Connection connection);
 
     MsgType _msg_type(redisReply *reply) const;
+    MsgType _msg_type(std::string const& type) const;
 
     void _check_connection();
 
@@ -160,9 +161,6 @@ private:
     using MetaCallback = std::function<void (MsgType type,
                                                 OptionalString channel,
                                                 long long num)>;
-
-    using TypeIndex = std::unordered_map<std::string, MsgType>;
-    static const TypeIndex _msg_type_index;
 
     Connection _connection;
 


### PR DESCRIPTION
The `Subscriber::_msg_type_index` is causing problems by being a static. In situations where a static/global/namespace scope client is created, the de-initialization does not guarantee that this member is "alive" by the time the destructor of the client is called. Since the creation of a subscriber always succeeds the creation of a redis client (one has to call `::subscriber()` from a client object) it is guaranteed that a static client will "die" **after** the static member of the subscriber.

This means that it's impossible to safely notify a subscriber thread (inside such a global client) that it's time to stop. If that subscriber has leftover messages, a `consume` call may contain a "dead" _msg_type_index object.