### PR TITLE
connection: support redis v4 -u url scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,12 @@ In order to run tests with both Redis and Redis Cluster, you can run the test pr
 ./build/test/test_redis++ -h host -p port -a auth -n cluster_node -c cluster_port
 ```
 
+Alternatively you can provide a redis connection uri with -u, e.g. "redis://127.0.0.1:6379":
+
+```
+./build/test/test_redis++ -u uri
+```
+
 - *host* and *port* are the host and port number of the Redis instance.
 - *cluster_node* and *cluster_port* are the host and port number of Redis Cluster. You only need to set the host and port number of a single node in the cluster, *redis-plus-plus* will find other nodes automatically.
 - *auth* is the password of the Redis instance and Redis Cluster. The Redis instance and Redis Cluster must be configured with the same password. If there's no password configured, don't set this option.

--- a/src/sw/redis++/connection.cpp
+++ b/src/sw/redis++/connection.cpp
@@ -53,7 +53,7 @@ ConnectionOptions ConnectionOptions::_parse_uri(const std::string &uri) const {
 
     opts.db = db;
 
-    if (type == "tcp") {
+    if (type == "tcp" || type == "redis") {
         _set_tcp_opts(path, opts);
     } else if (type == "unix") {
         _set_unix_opts(path, opts);
@@ -93,8 +93,6 @@ void ConnectionOptions::_set_option(const std::string &key,
         opts.connect_timeout = _parse_timeout_option(val);
     } else if (key == "socket_timeout") {
         opts.socket_timeout = _parse_timeout_option(val);
-    } else {
-        throw Error("unknown uri parameter");
     }
 }
 

--- a/test/src/sw/redis++/test_main.cpp
+++ b/test/src/sw/redis++/test_main.cpp
@@ -211,7 +211,7 @@ int getopt(int argc, char **argv, const char *optstring) {
 #endif
 
 void print_help() {
-    std::cerr << "Usage: test_redis++ -h host -p port"
+    std::cerr << "Usage: test_redis++ -h host -p port -u uri"
         << " -n cluster_node -c cluster_port [-a auth] [-b] [-e key_prefix]\n\n";
     std::cerr << "See https://github.com/sewenew/redis-plus-plus#run-tests-optional"
         << " for details on how to run test" << std::endl;
@@ -226,15 +226,20 @@ auto parse_options(int argc, char **argv)
     int port = 0;
     std::string auth;
     std::string cluster_node;
+    std::string uri;
     int cluster_port = 0;
     bool benchmark = false;
     sw::redis::test::BenchmarkOptions tmp_benchmark_opts;
     TestOptions test_options;
 
     int opt = 0;
-    while ((opt = getopt(argc, argv, "h:p:a:n:c:e:k:v:r:t:bs:m")) != -1) {
+    while ((opt = getopt(argc, argv, "u:h:p:a:n:c:e:k:v:r:t:bs:m")) != -1) {
         try {
             switch (opt) {
+            case 'u':
+                uri = optarg;
+                break;
+
             case 'h':
                 host = optarg;
                 break;
@@ -301,7 +306,9 @@ auto parse_options(int argc, char **argv)
     }
 
     sw::redis::Optional<sw::redis::ConnectionOptions> opts;
-    if (!host.empty() && port > 0) {
+    if (!uri.empty()) {
+        opts = sw::redis::Optional<sw::redis::ConnectionOptions>(uri);
+    } else if (!host.empty() && port > 0) {
         sw::redis::ConnectionOptions tmp;
         tmp.host = host;
         tmp.port = port;


### PR DESCRIPTION
Add support for redis:// scheme connection urls (added to redis-cli in
v4).

Allows unknown url query parameters to be ignored.