### PR TITLE
WIP:Add support c++20 coroutine

### DIFF
--- a/src/sw/redis++/future/boost/async_utils.h
+++ b/src/sw/redis++/future/boost/async_utils.h
@@ -17,6 +17,13 @@
 #ifndef SEWENEW_REDISPLUSPLUS_ASYNC_UTILS_H
 #define SEWENEW_REDISPLUSPLUS_ASYNC_UTILS_H
 
+#ifdef __cpp_impl_coroutine
+
+#define BOOST_THREAD_PROVIDES_EXECUTORS
+#define BOOST_THREAD_USES_MOVE
+
+#endif
+
 #define BOOST_THREAD_PROVIDES_FUTURE
 #define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
 
@@ -32,8 +39,109 @@ using Future = boost::future<T>;
 template <typename T>
 using Promise = boost::promise<T>;
 
-}
+} // namespace redis
 
-}
+} // namespace sw
+
+#ifdef __cpp_impl_coroutine
+
+#include <coroutine>
+
+#include <boost/thread/executors/basic_thread_pool.hpp>
+
+namespace sw {
+
+namespace redis {
+
+template <typename T>
+struct FutureAwaiter {
+    FutureAwaiter(boost::future<T>&& future)
+        : _future(std::move(future)) {
+    }
+
+    FutureAwaiter(boost::future<T>&& future, boost::executors::basic_thread_pool* pool_ptr)
+        : _future(std::move(future))
+        , _pool_ptr(pool_ptr) {
+    }
+
+    bool await_ready() { return false; }
+    void await_suspend(std::coroutine_handle<> handle) {
+        auto func = [this, handle](sw::redis::Future<T> fut) mutable {
+            try {
+                _result = fut.get();
+            } catch (...) {
+                try {
+                    boost::rethrow_exception(fut.get_exception_ptr());
+                } catch (const std::exception_ptr& ep) {
+                    _exception = ep;
+                }
+            }
+            handle.resume();
+        };
+        if (_pool_ptr != nullptr)
+            _future.then(*_pool_ptr, std::move(func));
+        else
+            _future.then(std::move(func));
+    }
+
+    T await_resume() {
+        if (_exception)
+            std::rethrow_exception(_exception);
+        return std::move(_result);
+    }
+
+    boost::future<T> _future;
+    boost::executors::basic_thread_pool* _pool_ptr{nullptr};
+    std::decay_t<decltype(std::declval<boost::future<T>>().get())> _result;
+    std::exception_ptr _exception{nullptr};
+};
+
+template <>
+struct FutureAwaiter<void> {
+    FutureAwaiter(boost::future<void>&& future)
+        : _future(std::move(future)) {
+    }
+
+    FutureAwaiter(boost::future<void>&& future, boost::executors::basic_thread_pool* pool_ptr)
+        : _future(std::move(future))
+        , _pool_ptr(pool_ptr) {
+    }
+
+    bool await_ready() { return false; }
+    void await_suspend(std::coroutine_handle<> handle) {
+        auto func = [this, handle](sw::redis::Future<void> fut) mutable {
+            try {
+                fut.wait();
+            } catch (...) {
+                try {
+                    boost::rethrow_exception(fut.get_exception_ptr());
+                } catch (const std::exception_ptr& ep) {
+                    _exception = ep;
+                }
+            }
+            handle.resume();
+        };
+        if (_pool_ptr != nullptr)
+            _future.then(*_pool_ptr, std::move(func));
+        else
+            _future.then(std::move(func));
+    }
+
+    void await_resume() {
+        if (_exception)
+            std::rethrow_exception(_exception);
+        return;
+    }
+
+    boost::future<void> _future;
+    boost::executors::basic_thread_pool* _pool_ptr{nullptr};
+    std::exception_ptr _exception{nullptr};
+};
+
+} // namespace redis
+
+} // namespace sw1
+
+#endif
 
 #endif // end SEWENEW_REDISPLUSPLUS_ASYNC_UTILS_H

--- a/src/sw/redis++/future/std/async_utils.h
+++ b/src/sw/redis++/future/std/async_utils.h
@@ -29,8 +29,90 @@ using Future = std::future<T>;
 template <typename T>
 using Promise = std::promise<T>;
 
-}
+} // namespace redis
 
-}
+} // namespace sw
+
+#ifdef __cpp_impl_coroutine
+
+#include <coroutine>
+namespace sw {
+
+namespace redis {
+
+class Executor {
+public:
+    Executor() = default;
+    virtual ~Executor() = default;
+
+    virtual void enqueue(std::function<void()>) = 0;
+};
+
+template <typename T>
+struct FutureAwaiter {
+    FutureAwaiter(std::future<T>&& future, Executor* executor_ptr)
+        : _future(std::move(future))
+        , _executor_ptr(executor_ptr) {
+    }
+
+    bool await_ready() { return false; }
+    void await_suspend(std::coroutine_handle<> handle) {
+        _executor_ptr->enqueue([this, handle] {
+            try {
+                _result = _future.get();
+            } catch (const std::exception&) {
+                _exception = std::current_exception();
+            }
+            handle.resume();
+        });
+    }
+
+    T await_resume() {
+        if (_exception)
+            std::rethrow_exception(_exception);
+        return std::move(_result);
+    }
+
+    std::future<T> _future;
+    Executor* _executor_ptr{nullptr};
+    std::decay_t<decltype(std::declval<std::future<T>>().get())> _result;
+    std::exception_ptr _exception{nullptr};
+};
+
+template <>
+struct FutureAwaiter<void> {
+    FutureAwaiter(std::future<void>&& future, Executor* executor_ptr)
+        : _future(std::move(future))
+        , _executor_ptr(executor_ptr) {
+    }
+
+    bool await_ready() { return false; }
+    void await_suspend(std::coroutine_handle<> handle) {
+        _executor_ptr->enqueue([this, handle] {
+            try {
+                _future.wait();
+            } catch (const std::exception&) {
+                _exception = std::current_exception();
+            }
+            handle.resume();
+        });
+    }
+
+    void await_resume() {
+        if (_exception)
+            std::rethrow_exception(_exception);
+        return;
+    }
+
+    std::future<void> _future;
+    Executor* _executor_ptr{nullptr};
+    std::exception_ptr _exception{nullptr};
+};
+
+} // namespace redis
+
+} // namespace sw
+
+#endif
 
 #endif // end SEWENEW_REDISPLUSPLUS_ASYNC_UTILS_H


### PR DESCRIPTION
```
#include <sw/redis++/async_redis++.h>

#include <iostream>
#include <utility>

#include <cppcoro/sync_wait.hpp>
#include <cppcoro/task.hpp>

int main() {
	sw::redis::ConnectionOptions opts;
	opts.host = "127.0.0.1";
	opts.port = 6379;
	sw::redis::ConnectionPoolOptions pool_opts;
	pool_opts.size = 3;
	sw::redis::AsyncRedis async_redis_cli(opts, pool_opts);
	boost::executors::basic_thread_pool pool(3);

	cppcoro::sync_wait([&]() -> cppcoro::task<> {
		try {
			std::unordered_map<std::string, std::string> m = {{"a", "b"}, {"c", "d"}};
			boost::future<void> hmset_res = async_redis_cli.hmset("hash", m.begin(), m.end());
			co_await sw::redis::FutureAwaiter{std::move(hmset_res), &pool};

			boost::future<bool> set_ret = async_redis_cli.set("name", "xiaoli");
			auto flag = co_await sw::redis::FutureAwaiter{std::move(set_ret), &pool};
			if (flag)
				std::cout << "set key success!!!" << std::endl;

			boost::future<std::optional<std::string>> get_data = async_redis_cli.get("name");
			auto data = co_await sw::redis::FutureAwaiter{std::move(get_data), &pool};
			if (data)
				std::cout << "name:" << data.value() << std::endl;

			boost::future<std::vector<std::string>> hgetall_res = async_redis_cli.hgetall<std::vector<std::string>>("hash");
			auto hgetall_data = co_await sw::redis::FutureAwaiter{std::move(hgetall_res)};
			for (auto& d : hgetall_data)
				std::cout << d << std::endl;
		} catch (const std::exception& e) {
			std::cout << "error:" << e.what() << std::endl;
		}
	}());
	return 0;
}

[15:36:39] root :: c837fca6f43a  ➜  /tmp » g++ test_boost_future.cpp -std=c++20 -lpthread -lcppcoro -lredis++ -fcoroutines -lboost_thread -lhiredis -luv -o test_boost_future_coro
[15:37:35] root :: c837fca6f43a  ➜  /tmp » ./test_boost_future_coro
set key success!!!
name:xiaoli
c
d
a
b


#include <sw/redis++/async_redis++.h>

#include <iostream>
#include <utility>

#include <cppcoro/sync_wait.hpp>
#include <cppcoro/task.hpp>

int main() {
	sw::redis::ConnectionOptions opts;
	opts.host = "127.0.0.1";
	opts.port = 6379;
	sw::redis::ConnectionPoolOptions pool_opts;
	pool_opts.size = 3;
	sw::redis::AsyncRedis async_redis_cli(opts, pool_opts);

	class MyExecutor : public sw::redis::Executor {
	public:
		virtual void enqueue(std::function<void()> cb) override {
			std::thread([cb = std::move(cb)]() mutable { cb(); }).detach();
		}
	};
	MyExecutor my_executor;

	cppcoro::sync_wait([&]() -> cppcoro::task<> {
		try {
			std::unordered_map<std::string, std::string> m = {{"a", "b"}, {"c", "d"}};
			std::future<void> hmset_res = async_redis_cli.hmset("hash", m.begin(), m.end());
			co_await sw::redis::FutureAwaiter{std::move(hmset_res), &my_executor};

			std::future<bool> set_ret = async_redis_cli.set("name", "xiaoli");
			auto flag = co_await sw::redis::FutureAwaiter{std::move(set_ret), &my_executor};
			if (flag)
				std::cout << "set key success!!!" << std::endl;

			std::future<std::optional<std::string>> get_data = async_redis_cli.get("key");
			auto data = co_await sw::redis::FutureAwaiter{std::move(get_data), &my_executor};
			if (data)
				std::cout << "data:" << data.value() << std::endl;

			std::future<std::vector<std::string>> hgetall_res = async_redis_cli.hgetall<std::vector<std::string>>("hash");
			auto hgetall_data = co_await sw::redis::FutureAwaiter{std::move(hgetall_res), &my_executor};
			for (auto& d : hgetall_data)
				std::cout << d << std::endl;
		} catch (const std::exception& e) {
			std::cout << "error:" << e.what() << std::endl;
		}
	}());
	return 0;
}


[15:42:25] root :: c837fca6f43a  ➜  /tmp/ » g++ test_std_future.cpp -std=c++20 -lpthread -lcppcoro -lredis++ -fcoroutines -lboost_thread -lhiredis -luv -o test_std_future_coro
[15:42:42] root :: c837fca6f43a  ➜  /tmp/ » ./test_std_future_coro                     
set key success!!!
data:hello world
c
d
a
b




```