### PR TITLE
redis++_static should link to hiredis_static 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,7 +214,6 @@ if(REDIS_PLUS_PLUS_BUILD_SHARED)
 
     add_library(${SHARED_LIB} SHARED ${REDIS_PLUS_PLUS_SOURCES})
     add_library(redis++::${SHARED_LIB} ALIAS ${SHARED_LIB})
-
     list(APPEND REDIS_PLUS_PLUS_TARGETS ${SHARED_LIB})
 
     target_include_directories(${SHARED_LIB} PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,8 @@ if(hiredis_FOUND)
     if(REDIS_PLUS_PLUS_USE_TLS)
         find_package(hiredis_ssl REQUIRED)
         list(APPEND REDIS_PLUS_PLUS_HIREDIS_LIBS hiredis::hiredis_ssl)
+        find_package(OpenSSL REQUIRED)
+        list(APPEND REDIS_PLUS_PLUS_HIREDIS_LIBS ${OPENSSL_LIBRARIES})
     endif()
 else()
     find_path(HIREDIS_HEADER hiredis)
@@ -136,6 +138,8 @@ else()
     if(REDIS_PLUS_PLUS_USE_TLS)
         find_library(HIREDIS_TLS_LIB hiredis_ssl)
         list(APPEND REDIS_PLUS_PLUS_HIREDIS_LIBS ${HIREDIS_TLS_LIB})
+        find_package(OpenSSL REQUIRED)
+        list(APPEND REDIS_PLUS_PLUS_HIREDIS_LIBS ${OPENSSL_LIBRARIES})
     endif()
 endif()
 
@@ -145,6 +149,15 @@ message(STATUS "redis-plus-plus build static library: ${REDIS_PLUS_PLUS_BUILD_ST
 
 if(REDIS_PLUS_PLUS_BUILD_STATIC)
     set(STATIC_LIB redis++_static)
+
+    # For the static build, link to the static version of hiredis
+    set(REDIS_PLUS_PLUS_HIREDIS_LIBS_STATIC ${REDIS_PLUS_PLUS_HIREDIS_LIBS})
+    string(REPLACE "hiredis::hiredis" "hiredis::hiredis_static" REDIS_PLUS_PLUS_HIREDIS_LIBS_STATIC
+      "${REDIS_PLUS_PLUS_HIREDIS_LIBS_STATIC}")
+
+    # If SSL is not enabled, this line will have no effect
+    string(REPLACE "hiredis::hiredis_ssl" "hiredis::hiredis_ssl_static" REDIS_PLUS_PLUS_HIREDIS_LIBS_STATIC
+      "${REDIS_PLUS_PLUS_HIREDIS_LIBS_STATIC}")
 
     add_library(${STATIC_LIB} STATIC ${REDIS_PLUS_PLUS_SOURCES})
     add_library(redis++::${STATIC_LIB} ALIAS ${STATIC_LIB})
@@ -159,7 +172,7 @@ if(REDIS_PLUS_PLUS_BUILD_STATIC)
 
     if(hiredis_FOUND)
         target_include_directories(${STATIC_LIB} PUBLIC $<BUILD_INTERFACE:${hiredis_INCLUDE_DIRS}>)
-        target_link_libraries(${STATIC_LIB} PUBLIC ${REDIS_PLUS_PLUS_HIREDIS_LIBS})
+        target_link_libraries(${STATIC_LIB} PUBLIC ${REDIS_PLUS_PLUS_HIREDIS_LIBS_STATIC})
     else()
         target_include_directories(${STATIC_LIB} PUBLIC $<BUILD_INTERFACE:${HIREDIS_HEADER}>)
     endif()
@@ -201,7 +214,7 @@ if(REDIS_PLUS_PLUS_BUILD_SHARED)
 
     add_library(${SHARED_LIB} SHARED ${REDIS_PLUS_PLUS_SOURCES})
     add_library(redis++::${SHARED_LIB} ALIAS ${SHARED_LIB})
-    
+
     list(APPEND REDIS_PLUS_PLUS_TARGETS ${SHARED_LIB})
 
     target_include_directories(${SHARED_LIB} PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,12 +152,17 @@ if(REDIS_PLUS_PLUS_BUILD_STATIC)
 
     # For the static build, link to the static version of hiredis
     set(REDIS_PLUS_PLUS_HIREDIS_LIBS_STATIC ${REDIS_PLUS_PLUS_HIREDIS_LIBS})
-    string(REPLACE "hiredis::hiredis" "hiredis::hiredis_static" REDIS_PLUS_PLUS_HIREDIS_LIBS_STATIC
-      "${REDIS_PLUS_PLUS_HIREDIS_LIBS_STATIC}")
 
-    # If SSL is not enabled, this line will have no effect
-    string(REPLACE "hiredis::hiredis_ssl" "hiredis::hiredis_ssl_static" REDIS_PLUS_PLUS_HIREDIS_LIBS_STATIC
-      "${REDIS_PLUS_PLUS_HIREDIS_LIBS_STATIC}")
+    if (TARGET hiredis::hiredis_static)
+      string(REPLACE "hiredis::hiredis" "hiredis::hiredis_static" REDIS_PLUS_PLUS_HIREDIS_LIBS_STATIC
+        "${REDIS_PLUS_PLUS_HIREDIS_LIBS_STATIC}")
+    endif()
+
+    if (TARGET hiredis::hiredis_ssl_static)
+      # If SSL is not enabled, this line will have no effect
+      string(REPLACE "hiredis::hiredis_ssl" "hiredis::hiredis_ssl_static" REDIS_PLUS_PLUS_HIREDIS_LIBS_STATIC
+        "${REDIS_PLUS_PLUS_HIREDIS_LIBS_STATIC}")
+    endif()
 
     add_library(${STATIC_LIB} STATIC ${REDIS_PLUS_PLUS_SOURCES})
     add_library(redis++::${STATIC_LIB} ALIAS ${STATIC_LIB})


### PR DESCRIPTION
Hi, thanks for the project I've been finding it very useful!

This pull request is fairly simple, it allows the `redis++_static` target to link to the `hiredis_static` target instead of the current `hiredis` target.

My project uses the static version of redis++ because it's intended to be deployed on embedded devices, and having as many dependencies included in the `libredis++.a` library makes configuration management much easier. Because `libredis++.a` currently links to `libhiredis.so`, I need to make sure that all deployment devices also receive the exact version of `libhiredis.so`, a problem is made a little more difficult because the hiredis can't be built in the same project, redis++ expects to find hiredis installed at the system level. ([This PR](https://github.com/sewenew/redis-plus-plus/pull/15) for reference)

The proposed PR introduces the cmake variable `REDIS_PLUS_PLUS_HIREDIS_LIBS_STATIC`, which is constructed from `REDIS_PLUS_PLUS_HIREDIS_LIBS`, but appends `_static` where necessary. I have tested on version with and without SSL.

Let me know if you have any questions, or if other edits are necessary.

Thanks