### PR TITLE
parse async scan command reply

### DIFF
--- a/src/sw/redis++/reply.h
+++ b/src/sw/redis++/reply.h
@@ -227,6 +227,11 @@ void to_array(redisReply &reply, Output output) {
             throw ProtoError("Null array element reply");
         }
 
+        if (is_array(*sub_reply)) {
+            reply::to_array(*sub_reply, output);
+            continue;
+        }
+
         *output = parse<typename IterType<Output>::type>(*sub_reply);
 
         ++output;


### PR DESCRIPTION
AsyncRedis doesn't support "scan" command.
Its redisReply should be checked recusively if array type.