### PR TITLE
Addresses CWE-190 integer overflow or wraparound.

### DIFF
--- a/src/sw/redis++/connection.cpp
+++ b/src/sw/redis++/connection.cpp
@@ -169,7 +169,14 @@ auto ConnectionOptions::_split_uri(const std::string &uri) const
 
     auto scheme = uri.substr(0, pos);
 
-    auto start = pos + 3;
+    auto start = pos;
+    if (std::string::npos - start > 3) {
+        start += 3;
+    }
+    else {
+        throw Error("size_t overflow");
+    }
+
     pos = uri.find("@", start);
     if (pos == std::string::npos) {
         // No auth info.

--- a/src/sw/redis++/sentinel.cpp
+++ b/src/sw/redis++/sentinel.cpp
@@ -296,7 +296,12 @@ Role Sentinel::_get_role(Connection &connection) {
     if (start == std::string::npos) {
         throw ProtoError("Invalid INFO REPLICATION reply");
     }
-    start += 5;
+    if (std::string::npos - start > 5) {
+        start += 5;
+    }
+    else {
+        throw Error("size_t overflow");
+    }
     auto stop = info.find("\r\n", start);
     if (stop == std::string::npos) {
         throw ProtoError("Invalid INFO REPLICATION reply");


### PR DESCRIPTION
Addresses 2 instances of CWE-190 integer overflow or wraparound (https://cwe.mitre.org/data/definitions/190.html), as reported by Veracode static analysis (https://www.veracode.com).

Co-Authored-By: jchuahp <118310970+jchuahp@users.noreply.github.com>