### PR TITLE
##Use a custom connection policy when IP port cannot be obtained directly##

### DIFF
--- a/src/sw/redis++/connection.cpp
+++ b/src/sw/redis++/connection.cpp
@@ -293,7 +293,13 @@ Connection::ContextUPtr Connection::Connector::_connect() const {
     case ConnectionType::UNIX:
         context = _connect_unix();
         break;
-
+    case ConnectionType::CUSTOM:
+        if (_opts.customConnectFn != nullptr) {
+            context = _opts.customConnectFn(_opts.customConnectArg);
+        } else {
+            throw Error("Function customConnectFn is invalid");
+        }
+        break;
     default:
         // Never goes here.
         throw Error("Unknown connection type");

--- a/src/sw/redis++/connection.h
+++ b/src/sw/redis++/connection.h
@@ -36,7 +36,8 @@ namespace redis {
 
 enum class ConnectionType {
     TCP = 0,
-    UNIX
+    UNIX,
+    CUSTOM
 };
 
 struct ConnectionOptions {
@@ -81,6 +82,15 @@ public:
 
     // RESP version.
     int resp = 2;
+
+    // if specify the `type` is ConnectionType::CUSTOM, it will use the customConnectFn create a 
+    // connection to redis server. This allows users to implement their own connection logic.
+    // After all, in many cases, the domain name or IP address is not given directly.
+    // For example, in the scenario of deploying some Redis instances with a microservice mode, a service name is given
+    redisContext* (*customConnectFn)(void *arg) = nullptr;
+
+    // parameter of custom functions
+    void *customConnectArg = nullptr;
 
 private:
     ConnectionOptions _parse_uri(const std::string &uri) const;


### PR DESCRIPTION
If specify the `type of connection_options` is `ConnectionType::CUSTOM`, it will use the `customConnectFn` create a connection to redis server. This allows users to implement their own connection logic.
After all, in many cases, the domain name or IP address is not given directly.
For example, in the scenario of deploying some Redis instances with a microservice mode, a service name is given.

We can use custom connect policy as follows.
First, we define a function which can connect to redis server.
`redisContext* customConnect(void *arg) {
    if (!arg) {
        // It is not necessary to throw an exception.
        // Because you do not need any parameters to obtain.
        throw Error("myConnectTCP parameter is invalid");
    }

    // If you need a parameter, type conversion is necessary when you know it's not nullptr.
    CustomConfType someConf = *(reinterpret_cast<CustomConfType*>(arg));
    
    // Do something as you need.
    // For example, obtain the real IP address through service discovery.
    doSomething();
	
    // Create a redisContext instance and return it's address.
    // Maybe you can refer to the following function.
    return redisConnect(hostIP.c_str(), hostPort); 

}`

Parameter to be passed to the custom function.
`
ConnectionOptions connection_options;
CustomConfType myConf;
connection_options.type = ConnectionType::CUSTOM;  // It's required if you want to use custom connect policy.
connection_options.customConnect = customConnect;  // It's required if you want to use custom connect policy.
connection_options.customConnectArg = &(myConf);  // Optional. The default is nullptr.
`


Connect to Redis server with a single connection and customize connect policy.
`Redis redis2(connection_options);`