### PR TITLE
async_sentinel.h: reorder fields to fix races in AsyncSentinel constructor

### DIFF
--- a/src/sw/redis++/async_sentinel.h
+++ b/src/sw/redis++/async_sentinel.h
@@ -73,11 +73,11 @@ private:
 
     std::shared_ptr<Sentinel> _sentinel;
 
-    std::thread _worker;
-
     std::mutex _mutex;
 
     std::condition_variable _cv;
+
+    std::thread _worker;
 };
 
 using AsyncSentinelSPtr = std::shared_ptr<AsyncSentinel>;


### PR DESCRIPTION
While developing application using AsyncSentinel I discovered there are races in the constructor of AsyncSentinel which are caused by the order of fields intialization. The fields `_mutex` and `_cv` are used by the thread `_worker` however this thread is created before the fields are initialized. This was causing random crashes in my application. I fixed this by reordering the fields and now the crashes are gone.