### PR TITLE
include <cstdint>

### DIFF
--- a/src/sw/redis++/utils.h
+++ b/src/sw/redis++/utils.h
@@ -17,6 +17,7 @@
 #ifndef SEWENEW_REDISPLUSPLUS_UTILS_H
 #define SEWENEW_REDISPLUSPLUS_UTILS_H
 
+#include <cstdint>
 #include <cstring>
 #include <string>
 #include <type_traits>


### PR DESCRIPTION
gcc 13 libstdc++ moved some includes around and as a result <cstdint> is no longer transitively included [1]. Explicitly include it for uintXX_t.

Fixes

../git/src/sw/redis++/utils.h:187:1: error: 'uint16_t' does not name a type
  187 | uint16_t crc16(const char *buf, int len);
      | ^~~~~~~~

[1] https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes

Signed-off-by: Khem Raj <raj.khem@gmail.com>