### PR TITLE
fix: identify reply of command `bgsave` uncorrectly.

### DIFF
--- a/src/sw/redis++/redis.cpp
+++ b/src/sw/redis++/redis.cpp
@@ -102,10 +102,10 @@ void Redis::bgrewriteaof() {
     reply::parse<void>(*reply);
 }
 
-void Redis::bgsave() {
-    auto reply = command(cmd::bgsave);
+std::string Redis::bgsave() {
+    auto reply = command<void (*)(Connection &)>(cmd::bgsave);
 
-    reply::parse<void>(*reply);
+    return reply::to_status(*reply);
 }
 
 long long Redis::dbsize() {

--- a/src/sw/redis++/redis.h
+++ b/src/sw/redis++/redis.h
@@ -222,8 +222,9 @@ public:
     void bgrewriteaof();
 
     /// @brief Save database in the background.
+    /// @return *Background saving started* if BGSAVE started correctly.
     /// @see https://redis.io/commands/bgsave
-    void bgsave();
+    std::string bgsave();
 
     /// @brief Get the size of the currently selected database.
     /// @return Number of keys in currently selected database.

--- a/src/sw/redis++/reply.cpp
+++ b/src/sw/redis++/reply.cpp
@@ -148,12 +148,14 @@ void parse(ParseTag<void>, redisReply &reply) {
     }
 
     static const std::string OK = "OK";
+    static const std::string BGSAVEOK = "Background saving started";
 
     // Old version hiredis' *redisReply::len* is of type int.
     // So we have to cast it to an unsigned int.
-    if (static_cast<std::size_t>(reply.len) != OK.size()
-            || OK.compare(0, OK.size(), reply.str, reply.len) != 0) {
-        throw ProtoError("NOT ok status reply: " + reply::to_status(reply));
+    if(BGSAVEOK.compare(0, BGSAVEOK.size(), reply.str, reply.len) != 0)
+        if (static_cast<std::size_t>(reply.len) != OK.size()
+                || OK.compare(0, OK.size(), reply.str, reply.len) != 0) {
+            throw ProtoError("NOT ok status reply: " + reply::to_status(reply));
     }
 }
 

--- a/src/sw/redis++/reply.cpp
+++ b/src/sw/redis++/reply.cpp
@@ -148,14 +148,12 @@ void parse(ParseTag<void>, redisReply &reply) {
     }
 
     static const std::string OK = "OK";
-    static const std::string BGSAVEOK = "Background saving started";
 
     // Old version hiredis' *redisReply::len* is of type int.
     // So we have to cast it to an unsigned int.
-    if(BGSAVEOK.compare(0, BGSAVEOK.size(), reply.str, reply.len) != 0)
-        if (static_cast<std::size_t>(reply.len) != OK.size()
-                || OK.compare(0, OK.size(), reply.str, reply.len) != 0) {
-            throw ProtoError("NOT ok status reply: " + reply::to_status(reply));
+    if (static_cast<std::size_t>(reply.len) != OK.size()
+            || OK.compare(0, OK.size(), reply.str, reply.len) != 0) {
+        throw ProtoError("NOT ok status reply: " + reply::to_status(reply));
     }
 }
 


### PR DESCRIPTION
The normal reply message of command `bgsave` should be 'Background saving started' but not 'OK'.