### PR TITLE
Check whether co-routine or experimental co-routine should be included

### DIFF
--- a/src/sw/redis++/co_redis.h
+++ b/src/sw/redis++/co_redis.h
@@ -17,7 +17,19 @@
 #ifndef SEWENEW_REDISPLUSPLUS_CO_REDIS_H
 #define SEWENEW_REDISPLUSPLUS_CO_REDIS_H
 
-#include <coroutine>
+#if __has_include(<coroutine>)
+# include <coroutine>
+#elif __has_include(<experimental/coroutine>)
+# include <experimental/coroutine>
+# ifndef coroutine_handle
+#  define coroutine_handle experimental::coroutine_handle
+# endif
+# ifndef suspend_never
+#  define suspend_never experimental::suspend_never
+# endif
+#else
+# error "<coroutine> not found."
+#endif
 #include "sw/redis++/async_redis.h"
 #include "sw/redis++/cxx_utils.h"
 #include "sw/redis++/cmd_formatter.h"

--- a/src/sw/redis++/co_redis_cluster.h
+++ b/src/sw/redis++/co_redis_cluster.h
@@ -17,7 +17,19 @@
 #ifndef SEWENEW_REDISPLUSPLUS_CO_REDIS_CLUSTER_H
 #define SEWENEW_REDISPLUSPLUS_CO_REDIS_CLUSTER_H
 
-#include <coroutine>
+#if __has_include(<coroutine>)
+# include <coroutine>
+#elif __has_include(<experimental/coroutine>)
+# include <experimental/coroutine>
+# ifndef coroutine_handle
+#  define coroutine_handle experimental::coroutine_handle
+# endif
+# ifndef suspend_never
+#  define suspend_never experimental::suspend_never
+# endif
+#else
+# error "<coroutine> not found."
+#endif
 #include "sw/redis++/async_redis_cluster.h"
 #include "sw/redis++/cxx_utils.h"
 #include "sw/redis++/cmd_formatter.h"


### PR DESCRIPTION
Given the experimental status of coroutines in C++20, different compilers have distinct locations for the coroutines headers.
Due to this, e.g. when using `clang` an `#include <experimental/coroutine>` is required instead of the normal coroutine include.

The code below is tested on `clang` versions `11` & `13` inside a `debian` based buildcontainer.