### PR TITLE
Changes for Nvidia compiler chain

### DIFF
--- a/src/sw/redis++/command.cpp
+++ b/src/sw/redis++/command.cpp
@@ -347,7 +347,6 @@ void set_geo_unit(CmdArgs &args, GeoUnit unit) {
 
     default:
         throw Error("Unknown geo unit type");
-        break;
     }
 }
 

--- a/src/sw/redis++/connection.cpp
+++ b/src/sw/redis++/connection.cpp
@@ -73,14 +73,21 @@ Connection::ContextUPtr Connection::Connector::connect() const {
 }
 
 Connection::ContextUPtr Connection::Connector::_connect() const {
+    const std::string failed_alloc_message = "Failed to allocate memory for connection.";
     redisContext *context = nullptr;
     switch (_opts.type) {
     case ConnectionType::TCP:
         context = _connect_tcp();
+        if (context == nullptr) {
+            throw Error(failed_alloc_message);
+        }
         break;
 
     case ConnectionType::UNIX:
         context = _connect_unix();
+        if (context == nullptr) {
+            throw Error(failed_alloc_message);
+        }
         break;
 
     default:
@@ -88,11 +95,9 @@ Connection::ContextUPtr Connection::Connector::_connect() const {
         throw Error("Unknown connection type");
     }
 
-    if (context == nullptr) {
-        throw Error("Failed to allocate memory for connection.");
-    }
-
     return ContextUPtr(context);
+
+
 }
 
 redisContext* Connection::Connector::_connect_tcp() const {
@@ -169,7 +174,6 @@ std::string ConnectionOptions::_server_info() const {
     default:
         // Never goes here.
         throw Error("unknown connection type");
-        break;
     }
 
     return info;

--- a/src/sw/redis++/errors.cpp
+++ b/src/sw/redis++/errors.cpp
@@ -54,28 +54,22 @@ void throw_error(const redisContext &context, const std::string &err_info) {
         } else {
             throw IoError(err_msg);
         }
-        break;
 
     case REDIS_ERR_EOF:
         throw ClosedError(err_msg);
-        break;
 
     case REDIS_ERR_PROTOCOL:
         throw ProtoError(err_msg);
-        break;
 
     case REDIS_ERR_OOM:
         throw OomError(err_msg);
-        break;
 
     case REDIS_ERR_OTHER:
         throw Error(err_msg);
-        break;
 
 #ifdef REDIS_ERR_TIMEOUT
     case REDIS_ERR_TIMEOUT:
         throw TimeoutError(err_msg);
-        break;
 #endif
 
     default:
@@ -99,15 +93,12 @@ void throw_error(const redisReply &reply) {
     switch (err_type) {
     case ReplyErrorType::MOVED:
         throw MovedError(err_msg);
-        break;
 
     case ReplyErrorType::ASK:
         throw AskError(err_msg);
-        break;
 
     default:
         throw ReplyError(err_str);
-        break;
     }
 }
 

--- a/src/sw/redis++/reply.h
+++ b/src/sw/redis++/reply.h
@@ -422,19 +422,21 @@ Variant<Args...> parse(ParseTag<Variant<Args...>>, redisReply &reply) {
 template <typename T, typename std::enable_if<IsSequenceContainer<T>::value, int>::type>
 T parse(ParseTag<T>, redisReply &reply) {
 #ifdef REDIS_PLUS_PLUS_RESP_VERSION_3
-    if (!is_array(reply) && !is_set(reply)) {
-        throw ParseError("ARRAY or SET", reply);
+    if (is_array(reply) || is_set(reply)) {
 #else
-    if (!is_array(reply)) {
+    if (is_array(reply)) {
 #endif
-        throw ParseError("ARRAY", reply);
+        T container;
+        to_array(reply, std::back_inserter(container));
+        return container;
     }
+#ifdef REDIS_PLUS_PLUS_RESP_VERSION_3
+    throw ParseError("ARRAY or SET", reply);
+#else
+    throw ParseError("ARRAY", reply);
+#endif
 
-    T container;
 
-    to_array(reply, std::back_inserter(container));
-
-    return container;
 }
 
 template <typename T, typename std::enable_if<IsAssociativeContainer<T>::value, int>::type>

--- a/src/sw/redis++/subscriber.cpp
+++ b/src/sw/redis++/subscriber.cpp
@@ -138,7 +138,6 @@ Subscriber::MsgType Subscriber::_msg_type(std::string const& type) const
     }
 
     throw ProtoError("Invalid message type.");
-    return MsgType::MESSAGE; // Silence "no return" warnings.
 }
 
 void Subscriber::_check_connection() {

--- a/test/src/sw/redis++/test_main.cpp
+++ b/test/src/sw/redis++/test_main.cpp
@@ -321,7 +321,6 @@ auto parse_options(int argc, char **argv)
 
             default:
                 throw sw::redis::Error("Unknown command line option");
-                break;
             }
         } catch (const sw::redis::Error &e) {
             print_help();


### PR DESCRIPTION
Compiling redis++ with the Nvidia compiler chain fails due to warnings thrown during compilation which are converted to errors because of the `-Wall` compilation flag. Nvidia's compilers are based on the PGI compilers which can be quite pedantic. In this case, a number of blocks of code are seen as unreachable either due to a 'break' immediately following a 'throw' or logic (in the case of reply.h).

The changes in this commit lead to a clean compilation of Redis++. Some of these changes lead to some code that is more verbose than is strictly needed, however are necessary to avoid warnings.