### PR TITLE
include cstring header for cxx_utils.h

### DIFF
--- a/src/sw/redis++/cxx11/sw/redis++/cxx_utils.h
+++ b/src/sw/redis++/cxx11/sw/redis++/cxx_utils.h
@@ -17,6 +17,7 @@
 #ifndef SEWENEW_REDISPLUSPLUS_CXX_UTILS_H
 #define SEWENEW_REDISPLUSPLUS_CXX_UTILS_H
 
+#include <cstring>
 #include <string>
 #include <functional>
 #include <type_traits>


### PR DESCRIPTION
cxx_utils.h uses std::strlen which is defined in cstring header. Hence, let's include it.