### PR TITLE
Async interface: fix use of forwarding references

### DIFF
--- a/src/sw/redis++/async_subscriber_impl.h
+++ b/src/sw/redis++/async_subscriber_impl.h
@@ -32,22 +32,22 @@ public:
 
     template <typename MsgCb>
     void on_message(MsgCb &&msg_callback) {
-        _msg_callback = std::move(msg_callback);
+        _msg_callback = std::forward<MsgCb>(msg_callback);
     }
 
     template <typename PMsgCb>
     void on_pmessage(PMsgCb &&pmsg_callback) {
-        _pmsg_callback = std::move(pmsg_callback);
+        _pmsg_callback = std::forward<PMsgCb>(pmsg_callback);
     }
 
     template <typename MetaCb>
     void on_meta(MetaCb &&meta_callback) {
-        _meta_callback = std::move(meta_callback);
+        _meta_callback = std::forward<MetaCb>(meta_callback);
     }
 
     template <typename ErrCb>
     void on_error(ErrCb &&err_callback) {
-        _err_callback = std::move(err_callback);
+        _err_callback = std::forward<ErrCb>(err_callback);
     }
 
 private:


### PR DESCRIPTION
The following function template needs to be fixed, since it makes possible to move the `msg_callback` passed by lvalue reference:
```c++
template <typename MsgCb>
void on_message(MsgCb &&msg_callback) {
    _msg_callback = std::move(msg_callback);
}
```
Here (and also in other similar cases), `std::move` should be replaced with `std::forward`:
```c++
    _msg_callback = std::forward<MsgCb>(msg_callback);
```
