### PR TITLE
Use unsigned type for cursors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1336,7 +1336,7 @@ redis.smembers("s1", std::back_inserter(s_vec));
 ##### SCAN Commands
 
 ```C++
-auto cursor = 0LL;
+sw::redis::Cursor cursor = 0;
 auto pattern = "*pattern*";
 auto count = 5;
 std::unordered_set<std::string> keys;

--- a/src/sw/redis++/command.h
+++ b/src/sw/redis++/command.h
@@ -233,10 +233,10 @@ void restore(Connection &connection,
                 bool replace);
 
 inline void scan(Connection &connection,
-                    long long cursor,
+                    Cursor cursor,
                     const StringView &pattern,
                     long long count) {
-    connection.send("SCAN %lld MATCH %b COUNT %lld",
+    connection.send("SCAN %llu MATCH %b COUNT %lld",
                     cursor,
                     pattern.data(), pattern.size(),
                     count);
@@ -729,10 +729,10 @@ inline void hmset(Connection &connection,
 
 inline void hscan(Connection &connection,
                     const StringView &key,
-                    long long cursor,
+                    Cursor cursor,
                     const StringView &pattern,
                     long long count) {
-    connection.send("HSCAN %b %lld MATCH %b COUNT %lld",
+    connection.send("HSCAN %b %llu MATCH %b COUNT %lld",
                     key.data(), key.size(),
                     cursor,
                     pattern.data(), pattern.size(),
@@ -937,10 +937,10 @@ inline void srem_range(Connection &connection,
 
 inline void sscan(Connection &connection,
                     const StringView &key,
-                    long long cursor,
+                    Cursor cursor,
                     const StringView &pattern,
                     long long count) {
-    connection.send("SSCAN %b %lld MATCH %b COUNT %lld",
+    connection.send("SSCAN %b %llu MATCH %b COUNT %lld",
                     key.data(), key.size(),
                     cursor,
                     pattern.data(), pattern.size(),
@@ -1294,10 +1294,10 @@ inline void zrevrank(Connection &connection,
 
 inline void zscan(Connection &connection,
                     const StringView &key,
-                    long long cursor,
+                    Cursor cursor,
                     const StringView &pattern,
                     long long count) {
-    connection.send("ZSCAN %b %lld MATCH %b COUNT %lld",
+    connection.send("ZSCAN %b %llu MATCH %b COUNT %lld",
                     key.data(), key.size(),
                     cursor,
                     pattern.data(), pattern.size(),

--- a/src/sw/redis++/cxx17/sw/redis++/cxx_utils.h
+++ b/src/sw/redis++/cxx17/sw/redis++/cxx_utils.h
@@ -43,6 +43,8 @@ using Monostate = std::monostate;
 template <typename F, typename ...Args>
 using IsInvocable = std::is_invocable<F, Args...>;
 
+using Cursor = unsigned long long;
+
 }
 
 }

--- a/src/sw/redis++/queued_redis.h
+++ b/src/sw/redis++/queued_redis.h
@@ -260,22 +260,22 @@ public:
 
     // TODO: sort
 
-    QueuedRedis& scan(long long cursor,
+    QueuedRedis& scan(Cursor cursor,
                         const StringView &pattern,
                         long long count) {
         return command(cmd::scan, cursor, pattern, count);
     }
 
-    QueuedRedis& scan(long long cursor) {
+    QueuedRedis& scan(Cursor cursor) {
         return scan(cursor, "*", 10);
     }
 
-    QueuedRedis& scan(long long cursor,
+    QueuedRedis& scan(Cursor cursor,
                         const StringView &pattern) {
         return scan(cursor, pattern, 10);
     }
 
-    QueuedRedis& scan(long long cursor,
+    QueuedRedis& scan(Cursor cursor,
                         long long count) {
         return scan(cursor, "*", count);
     }
@@ -740,26 +740,26 @@ public:
     }
 
     QueuedRedis& hscan(const StringView &key,
-                        long long cursor,
+                        Cursor cursor,
                         const StringView &pattern,
                         long long count) {
         return command(cmd::hscan, key, cursor, pattern, count);
     }
 
     QueuedRedis& hscan(const StringView &key,
-                        long long cursor,
+                        Cursor cursor,
                         const StringView &pattern) {
         return hscan(key, cursor, pattern, 10);
     }
 
     QueuedRedis& hscan(const StringView &key,
-                        long long cursor,
+                        Cursor cursor,
                         long long count) {
         return hscan(key, cursor, "*", count);
     }
 
     QueuedRedis& hscan(const StringView &key,
-                        long long cursor) {
+                        Cursor cursor) {
         return hscan(key, cursor, "*", 10);
     }
 
@@ -930,26 +930,26 @@ public:
     }
 
     QueuedRedis& sscan(const StringView &key,
-                        long long cursor,
+                        Cursor cursor,
                         const StringView &pattern,
                         long long count) {
         return command(cmd::sscan, key, cursor, pattern, count);
     }
 
     QueuedRedis& sscan(const StringView &key,
-                    long long cursor,
+                    Cursor cursor,
                     const StringView &pattern) {
         return sscan(key, cursor, pattern, 10);
     }
 
     QueuedRedis& sscan(const StringView &key,
-                        long long cursor,
+                        Cursor cursor,
                         long long count) {
         return sscan(key, cursor, "*", count);
     }
 
     QueuedRedis& sscan(const StringView &key,
-                        long long cursor) {
+                        Cursor cursor) {
         return sscan(key, cursor, "*", 10);
     }
 
@@ -1250,26 +1250,26 @@ public:
     }
 
     QueuedRedis& zscan(const StringView &key,
-                        long long cursor,
+                        Cursor cursor,
                         const StringView &pattern,
                         long long count) {
         return command(cmd::zscan, key, cursor, pattern, count);
     }
 
     QueuedRedis& zscan(const StringView &key,
-                        long long cursor,
+                        Cursor cursor,
                         const StringView &pattern) {
         return zscan(key, cursor, pattern, 10);
     }
 
     QueuedRedis& zscan(const StringView &key,
-                        long long cursor,
+                        Cursor cursor,
                         long long count) {
         return zscan(key, cursor, "*", count);
     }
 
     QueuedRedis& zscan(const StringView &key,
-                        long long cursor) {
+                        Cursor cursor) {
         return zscan(key, cursor, "*", 10);
     }
 

--- a/src/sw/redis++/redis.h
+++ b/src/sw/redis++/redis.h
@@ -480,7 +480,7 @@ public:
     ///
     /// Example:
     /// @code{.cpp}
-    /// auto cursor = 0LL;
+    /// sw::redis::Cursor cursor = 0;
     /// std::unordered_set<std::string> keys;
     /// while (true) {
     ///     cursor = redis.scan(cursor, "pattern:*", 10, std::inserter(keys, keys.begin()));
@@ -497,10 +497,10 @@ public:
     /// @see https://redis.io/commands/scan
     /// TODO: support the TYPE option for Redis 6.0.
     template <typename Output>
-    long long scan(long long cursor,
-                    const StringView &pattern,
-                    long long count,
-                    Output output);
+    Cursor scan(Cursor cursor,
+                 const StringView &pattern,
+                 long long count,
+                 Output output);
 
     /// @brief Scan all keys of the database.
     /// @param cursor Cursor.
@@ -508,8 +508,8 @@ public:
     /// @return The cursor to be used for the next scan operation.
     /// @see https://redis.io/commands/scan
     template <typename Output>
-    long long scan(long long cursor,
-                    Output output);
+    Cursor scan(Cursor cursor,
+                 Output output);
 
     /// @brief Scan keys of the database matching the given pattern.
     /// @param cursor Cursor.
@@ -518,9 +518,9 @@ public:
     /// @return The cursor to be used for the next scan operation.
     /// @see https://redis.io/commands/scan
     template <typename Output>
-    long long scan(long long cursor,
-                    const StringView &pattern,
-                    Output output);
+    Cursor scan(Cursor cursor,
+                 const StringView &pattern,
+                 Output output);
 
     /// @brief Scan keys of the database matching the given pattern.
     /// @param cursor Cursor.
@@ -529,9 +529,9 @@ public:
     /// @return The cursor to be used for the next scan operation.
     /// @see https://redis.io/commands/scan
     template <typename Output>
-    long long scan(long long cursor,
-                    long long count,
-                    Output output);
+    Cursor scan(Cursor cursor,
+                 long long count,
+                 Output output);
 
     /// @brief Update the last access time of the given key.
     /// @param key Key.
@@ -1490,7 +1490,7 @@ public:
     ///
     /// Example:
     /// @code{.cpp}
-    /// auto cursor = 0LL;
+    /// sw::redis::Cursor cursor = 0;
     /// std::unordered_map<std::string, std::string> kvs;
     /// while (true) {
     ///     cursor = redis.hscan("hash", cursor, "pattern:*", 10, std::inserter(kvs, kvs.begin()));
@@ -1507,11 +1507,11 @@ public:
     /// @return The cursor to be used for the next scan operation.
     /// @see https://redis.io/commands/hscan
     template <typename Output>
-    long long hscan(const StringView &key,
-                    long long cursor,
-                    const StringView &pattern,
-                    long long count,
-                    Output output);
+    Cursor hscan(const StringView &key,
+                 Cursor cursor,
+                 const StringView &pattern,
+                 long long count,
+                 Output output);
 
     /// @brief Scan fields of the given hash matching the given pattern.
     /// @param key Key where the hash is stored.
@@ -1521,10 +1521,10 @@ public:
     /// @return The cursor to be used for the next scan operation.
     /// @see https://redis.io/commands/hscan
     template <typename Output>
-    long long hscan(const StringView &key,
-                    long long cursor,
-                    const StringView &pattern,
-                    Output output);
+    Cursor hscan(const StringView &key,
+                 Cursor cursor,
+                 const StringView &pattern,
+                 Output output);
 
     /// @brief Scan all fields of the given hash.
     /// @param key Key where the hash is stored.
@@ -1534,10 +1534,10 @@ public:
     /// @return The cursor to be used for the next scan operation.
     /// @see https://redis.io/commands/hscan
     template <typename Output>
-    long long hscan(const StringView &key,
-                    long long cursor,
-                    long long count,
-                    Output output);
+    Cursor hscan(const StringView &key,
+                 Cursor cursor,
+                 long long count,
+                 Output output);
 
     /// @brief Scan all fields of the given hash.
     /// @param key Key where the hash is stored.
@@ -1546,9 +1546,9 @@ public:
     /// @return The cursor to be used for the next scan operation.
     /// @see https://redis.io/commands/hscan
     template <typename Output>
-    long long hscan(const StringView &key,
-                    long long cursor,
-                    Output output);
+    Cursor hscan(const StringView &key,
+                 Cursor cursor,
+                 Output output);
 
     /// @brief Set hash field to value.
     /// @param key Key where the hash is stored.
@@ -1875,7 +1875,7 @@ public:
     ///
     /// Example:
     /// @code{.cpp}
-    /// auto cursor = 0LL;
+    /// sw::redis::Cursor cursor = 0;
     /// std::unordered_set<std::string> members;
     /// while (true) {
     ///     cursor = redis.sscan("set", cursor, "pattern:*",
@@ -1893,11 +1893,11 @@ public:
     /// @return The cursor to be used for the next scan operation.
     /// @see https://redis.io/commands/sscan
     template <typename Output>
-    long long sscan(const StringView &key,
-                    long long cursor,
-                    const StringView &pattern,
-                    long long count,
-                    Output output);
+    Cursor sscan(const StringView &key,
+                 Cursor cursor,
+                 const StringView &pattern,
+                 long long count,
+                 Output output);
 
     /// @brief Scan members of the set matching the given pattern.
     /// @param key Key where the set is stored.
@@ -1907,10 +1907,10 @@ public:
     /// @return The cursor to be used for the next scan operation.
     /// @see https://redis.io/commands/sscan
     template <typename Output>
-    long long sscan(const StringView &key,
-                    long long cursor,
-                    const StringView &pattern,
-                    Output output);
+    Cursor sscan(const StringView &key,
+                 Cursor cursor,
+                 const StringView &pattern,
+                 Output output);
 
     /// @brief Scan all members of the given set.
     /// @param key Key where the set is stored.
@@ -1920,10 +1920,10 @@ public:
     /// @return The cursor to be used for the next scan operation.
     /// @see https://redis.io/commands/sscan
     template <typename Output>
-    long long sscan(const StringView &key,
-                    long long cursor,
-                    long long count,
-                    Output output);
+    Cursor sscan(const StringView &key,
+                 Cursor cursor,
+                 long long count,
+                 Output output);
 
     /// @brief Scan all members of the given set.
     /// @param key Key where the set is stored.
@@ -1932,9 +1932,9 @@ public:
     /// @return The cursor to be used for the next scan operation.
     /// @see https://redis.io/commands/sscan
     template <typename Output>
-    long long sscan(const StringView &key,
-                    long long cursor,
-                    Output output);
+    Cursor sscan(const StringView &key,
+                 Cursor cursor,
+                 Output output);
 
     /// @brief Get the union between the first set and all successive sets.
     /// @param first Iterator to the first set.
@@ -2811,7 +2811,7 @@ public:
     ///
     /// Example:
     /// @code{.cpp}
-    /// auto cursor = 0LL;
+    /// sw::redis::Cursor cursor = 0;
     /// std::vector<std::pair<std::string, double>> members;
     /// while (true) {
     ///     cursor = redis.zscan("zset", cursor, "pattern:*",
@@ -2829,11 +2829,11 @@ public:
     /// @return The cursor to be used for the next scan operation.
     /// @see https://redis.io/commands/zscan
     template <typename Output>
-    long long zscan(const StringView &key,
-                    long long cursor,
-                    const StringView &pattern,
-                    long long count,
-                    Output output);
+    Cursor zscan(const StringView &key,
+                 Cursor cursor,
+                 const StringView &pattern,
+                 long long count,
+                 Output output);
 
     /// @brief Scan members of the given sorted set matching the given pattern.
     /// @param key Key where the sorted set is stored.
@@ -2843,10 +2843,10 @@ public:
     /// @return The cursor to be used for the next scan operation.
     /// @see https://redis.io/commands/zscan
     template <typename Output>
-    long long zscan(const StringView &key,
-                    long long cursor,
-                    const StringView &pattern,
-                    Output output);
+    Cursor zscan(const StringView &key,
+                 Cursor cursor,
+                 const StringView &pattern,
+                 Output output);
 
     /// @brief Scan all members of the given sorted set.
     /// @param key Key where the sorted set is stored.
@@ -2856,10 +2856,10 @@ public:
     /// @return The cursor to be used for the next scan operation.
     /// @see https://redis.io/commands/zscan
     template <typename Output>
-    long long zscan(const StringView &key,
-                    long long cursor,
-                    long long count,
-                    Output output);
+    Cursor zscan(const StringView &key,
+                 Cursor cursor,
+                 long long count,
+                 Output output);
 
     /// @brief Scan all members of the given sorted set.
     /// @param key Key where the sorted set is stored.
@@ -2868,9 +2868,9 @@ public:
     /// @return The cursor to be used for the next scan operation.
     /// @see https://redis.io/commands/zscan
     template <typename Output>
-    long long zscan(const StringView &key,
-                    long long cursor,
-                    Output output);
+    Cursor zscan(const StringView &key,
+                 Cursor cursor,
+                 Output output);
 
     /// @brief Get the score of the given member.
     /// @param key Key where the sorted set is stored.

--- a/src/sw/redis++/redis.hpp
+++ b/src/sw/redis++/redis.hpp
@@ -173,32 +173,32 @@ inline void Redis::restore(const StringView &key,
 }
 
 template <typename Output>
-long long Redis::scan(long long cursor,
-                    const StringView &pattern,
-                    long long count,
-                    Output output) {
+Cursor Redis::scan(Cursor cursor,
+                 const StringView &pattern,
+                 long long count,
+                 Output output) {
     auto reply = command(cmd::scan, cursor, pattern, count);
 
     return reply::parse_scan_reply(*reply, output);
 }
 
 template <typename Output>
-inline long long Redis::scan(long long cursor,
-                                const StringView &pattern,
-                                Output output) {
+inline Cursor Redis::scan(Cursor cursor,
+                             const StringView &pattern,
+                             Output output) {
     return scan(cursor, pattern, 10, output);
 }
 
 template <typename Output>
-inline long long Redis::scan(long long cursor,
-                                long long count,
-                                Output output) {
+inline Cursor Redis::scan(Cursor cursor,
+                             long long count,
+                             Output output) {
     return scan(cursor, "*", count, output);
 }
 
 template <typename Output>
-inline long long Redis::scan(long long cursor,
-                                Output output) {
+inline Cursor Redis::scan(Cursor cursor,
+                             Output output) {
     return scan(cursor, "*", 10, output);
 }
 
@@ -383,36 +383,36 @@ inline void Redis::hmset(const StringView &key, Input first, Input last) {
 }
 
 template <typename Output>
-long long Redis::hscan(const StringView &key,
-                        long long cursor,
-                        const StringView &pattern,
-                        long long count,
-                        Output output) {
+Cursor Redis::hscan(const StringView &key,
+                     Cursor cursor,
+                     const StringView &pattern,
+                     long long count,
+                     Output output) {
     auto reply = command(cmd::hscan, key, cursor, pattern, count);
 
     return reply::parse_scan_reply(*reply, output);
 }
 
 template <typename Output>
-inline long long Redis::hscan(const StringView &key,
-                                long long cursor,
-                                const StringView &pattern,
-                                Output output) {
+inline Cursor Redis::hscan(const StringView &key,
+                             Cursor cursor,
+                             const StringView &pattern,
+                             Output output) {
     return hscan(key, cursor, pattern, 10, output);
 }
 
 template <typename Output>
-inline long long Redis::hscan(const StringView &key,
-                                long long cursor,
-                                long long count,
-                                Output output) {
+inline Cursor Redis::hscan(const StringView &key,
+                             Cursor cursor,
+                             long long count,
+                             Output output) {
     return hscan(key, cursor, "*", count, output);
 }
 
 template <typename Output>
-inline long long Redis::hscan(const StringView &key,
-                                long long cursor,
-                                Output output) {
+inline Cursor Redis::hscan(const StringView &key,
+                             Cursor cursor,
+                             Output output) {
     return hscan(key, cursor, "*", 10, output);
 }
 
@@ -516,36 +516,36 @@ long long Redis::srem(const StringView &key, Input first, Input last) {
 }
 
 template <typename Output>
-long long Redis::sscan(const StringView &key,
-                        long long cursor,
-                        const StringView &pattern,
-                        long long count,
-                        Output output) {
+Cursor Redis::sscan(const StringView &key,
+                      Cursor cursor,
+                      const StringView &pattern,
+                      long long count,
+                      Output output) {
     auto reply = command(cmd::sscan, key, cursor, pattern, count);
 
     return reply::parse_scan_reply(*reply, output);
 }
 
 template <typename Output>
-inline long long Redis::sscan(const StringView &key,
-                                long long cursor,
-                                const StringView &pattern,
-                                Output output) {
+inline Cursor Redis::sscan(const StringView &key,
+                             Cursor cursor,
+                             const StringView &pattern,
+                             Output output) {
     return sscan(key, cursor, pattern, 10, output);
 }
 
 template <typename Output>
-inline long long Redis::sscan(const StringView &key,
-                                long long cursor,
-                                long long count,
-                                Output output) {
+inline Cursor Redis::sscan(const StringView &key,
+                             Cursor cursor,
+                             long long count,
+                             Output output) {
     return sscan(key, cursor, "*", count, output);
 }
 
 template <typename Output>
-inline long long Redis::sscan(const StringView &key,
-                                long long cursor,
-                                Output output) {
+inline Cursor Redis::sscan(const StringView &key,
+                             Cursor cursor,
+                             Output output) {
     return sscan(key, cursor, "*", 10, output);
 }
 
@@ -773,36 +773,36 @@ void Redis::zrevrangebyscore(const StringView &key,
 }
 
 template <typename Output>
-long long Redis::zscan(const StringView &key,
-                        long long cursor,
-                        const StringView &pattern,
-                        long long count,
-                        Output output) {
+Cursor Redis::zscan(const StringView &key,
+                     Cursor cursor,
+                     const StringView &pattern,
+                     long long count,
+                     Output output) {
     auto reply = command(cmd::zscan, key, cursor, pattern, count);
 
     return reply::parse_scan_reply(*reply, output);
 }
 
 template <typename Output>
-inline long long Redis::zscan(const StringView &key,
-                                long long cursor,
-                                const StringView &pattern,
-                                Output output) {
+inline Cursor Redis::zscan(const StringView &key,
+                             Cursor cursor,
+                             const StringView &pattern,
+                             Output output) {
     return zscan(key, cursor, pattern, 10, output);
 }
 
 template <typename Output>
-inline long long Redis::zscan(const StringView &key,
-                                long long cursor,
-                                long long count,
-                                Output output) {
+inline Cursor Redis::zscan(const StringView &key,
+                             Cursor cursor,
+                             long long count,
+                             Output output) {
     return zscan(key, cursor, "*", count, output);
 }
 
 template <typename Output>
-inline long long Redis::zscan(const StringView &key,
-                                long long cursor,
-                                Output output) {
+inline Cursor Redis::zscan(const StringView &key,
+                             Cursor cursor,
+                             Output output) {
     return zscan(key, cursor, "*", 10, output);
 }
 

--- a/src/sw/redis++/redis_cluster.h
+++ b/src/sw/redis++/redis_cluster.h
@@ -447,28 +447,28 @@ public:
     }
 
     template <typename Output>
-    long long hscan(const StringView &key,
-                    long long cursor,
-                    const StringView &pattern,
-                    long long count,
-                    Output output);
+    Cursor hscan(const StringView &key,
+                 Cursor cursor,
+                 const StringView &pattern,
+                 long long count,
+                 Output output);
 
     template <typename Output>
-    long long hscan(const StringView &key,
-                    long long cursor,
-                    const StringView &pattern,
-                    Output output);
+    Cursor hscan(const StringView &key,
+                 Cursor cursor,
+                 const StringView &pattern,
+                 Output output);
 
     template <typename Output>
-    long long hscan(const StringView &key,
-                    long long cursor,
-                    long long count,
-                    Output output);
+    Cursor hscan(const StringView &key,
+                 Cursor cursor,
+                 long long count,
+                 Output output);
 
     template <typename Output>
-    long long hscan(const StringView &key,
-                    long long cursor,
-                    Output output);
+    Cursor hscan(const StringView &key,
+                 Cursor cursor,
+                 Output output);
 
     long long hset(const StringView &key, const StringView &field, const StringView &val);
 
@@ -578,28 +578,28 @@ public:
     }
 
     template <typename Output>
-    long long sscan(const StringView &key,
-                    long long cursor,
-                    const StringView &pattern,
-                    long long count,
-                    Output output);
+    Cursor sscan(const StringView &key,
+                 Cursor cursor,
+                 const StringView &pattern,
+                 long long count,
+                 Output output);
 
     template <typename Output>
-    long long sscan(const StringView &key,
-                    long long cursor,
-                    const StringView &pattern,
-                    Output output);
+    Cursor sscan(const StringView &key,
+                 Cursor cursor,
+                 const StringView &pattern,
+                 Output output);
 
     template <typename Output>
-    long long sscan(const StringView &key,
-                    long long cursor,
-                    long long count,
-                    Output output);
+    Cursor sscan(const StringView &key,
+                 Cursor cursor,
+                 long long count,
+                 Output output);
 
     template <typename Output>
-    long long sscan(const StringView &key,
-                    long long cursor,
-                    Output output);
+    Cursor sscan(const StringView &key,
+                 Cursor cursor,
+                 Output output);
 
     template <typename Input, typename Output>
     void sunion(Input first, Input last, Output output);
@@ -825,28 +825,28 @@ public:
     OptionalLongLong zrevrank(const StringView &key, const StringView &member);
 
     template <typename Output>
-    long long zscan(const StringView &key,
-                    long long cursor,
-                    const StringView &pattern,
-                    long long count,
-                    Output output);
+    Cursor zscan(const StringView &key,
+                 Cursor cursor,
+                 const StringView &pattern,
+                 long long count,
+                 Output output);
 
     template <typename Output>
-    long long zscan(const StringView &key,
-                    long long cursor,
-                    const StringView &pattern,
-                    Output output);
+    Cursor zscan(const StringView &key,
+                 Cursor cursor,
+                 const StringView &pattern,
+                 Output output);
 
     template <typename Output>
-    long long zscan(const StringView &key,
-                    long long cursor,
-                    long long count,
-                    Output output);
+    Cursor zscan(const StringView &key,
+                 Cursor cursor,
+                 long long count,
+                 Output output);
 
     template <typename Output>
-    long long zscan(const StringView &key,
-                    long long cursor,
-                    Output output);
+    Cursor zscan(const StringView &key,
+                 Cursor cursor,
+                 Output output);
 
     OptionalDouble zscore(const StringView &key, const StringView &member);
 

--- a/src/sw/redis++/redis_cluster.hpp
+++ b/src/sw/redis++/redis_cluster.hpp
@@ -354,36 +354,36 @@ inline void RedisCluster::hmset(const StringView &key, Input first, Input last) 
 }
 
 template <typename Output>
-long long RedisCluster::hscan(const StringView &key,
-                        long long cursor,
-                        const StringView &pattern,
-                        long long count,
-                        Output output) {
+Cursor RedisCluster::hscan(const StringView &key,
+                     Cursor cursor,
+                     const StringView &pattern,
+                     long long count,
+                     Output output) {
     auto reply = command(cmd::hscan, key, cursor, pattern, count);
 
     return reply::parse_scan_reply(*reply, output);
 }
 
 template <typename Output>
-inline long long RedisCluster::hscan(const StringView &key,
-                                long long cursor,
-                                const StringView &pattern,
-                                Output output) {
+inline Cursor RedisCluster::hscan(const StringView &key,
+                             Cursor cursor,
+                             const StringView &pattern,
+                             Output output) {
     return hscan(key, cursor, pattern, 10, output);
 }
 
 template <typename Output>
-inline long long RedisCluster::hscan(const StringView &key,
-                                long long cursor,
-                                long long count,
-                                Output output) {
+inline Cursor RedisCluster::hscan(const StringView &key,
+                             Cursor cursor,
+                             long long count,
+                             Output output) {
     return hscan(key, cursor, "*", count, output);
 }
 
 template <typename Output>
-inline long long RedisCluster::hscan(const StringView &key,
-                                long long cursor,
-                                Output output) {
+inline Cursor RedisCluster::hscan(const StringView &key,
+                             Cursor cursor,
+                             Output output) {
     return hscan(key, cursor, "*", 10, output);
 }
 
@@ -487,36 +487,36 @@ long long RedisCluster::srem(const StringView &key, Input first, Input last) {
 }
 
 template <typename Output>
-long long RedisCluster::sscan(const StringView &key,
-                        long long cursor,
-                        const StringView &pattern,
-                        long long count,
-                        Output output) {
+Cursor RedisCluster::sscan(const StringView &key,
+                     Cursor cursor,
+                     const StringView &pattern,
+                     long long count,
+                     Output output) {
     auto reply = command(cmd::sscan, key, cursor, pattern, count);
 
     return reply::parse_scan_reply(*reply, output);
 }
 
 template <typename Output>
-inline long long RedisCluster::sscan(const StringView &key,
-                                long long cursor,
-                                const StringView &pattern,
-                                Output output) {
+inline Cursor RedisCluster::sscan(const StringView &key,
+                             Cursor cursor,
+                             const StringView &pattern,
+                             Output output) {
     return sscan(key, cursor, pattern, 10, output);
 }
 
 template <typename Output>
-inline long long RedisCluster::sscan(const StringView &key,
-                                long long cursor,
-                                long long count,
-                                Output output) {
+inline Cursor RedisCluster::sscan(const StringView &key,
+                             Cursor cursor,
+                             long long count,
+                             Output output) {
     return sscan(key, cursor, "*", count, output);
 }
 
 template <typename Output>
-inline long long RedisCluster::sscan(const StringView &key,
-                                long long cursor,
-                                Output output) {
+inline Cursor RedisCluster::sscan(const StringView &key,
+                             Cursor cursor,
+                             Output output) {
     return sscan(key, cursor, "*", 10, output);
 }
 
@@ -744,36 +744,36 @@ void RedisCluster::zrevrangebyscore(const StringView &key,
 }
 
 template <typename Output>
-long long RedisCluster::zscan(const StringView &key,
-                        long long cursor,
-                        const StringView &pattern,
-                        long long count,
-                        Output output) {
+Cursor RedisCluster::zscan(const StringView &key,
+                     Cursor cursor,
+                     const StringView &pattern,
+                     long long count,
+                     Output output) {
     auto reply = command(cmd::zscan, key, cursor, pattern, count);
 
     return reply::parse_scan_reply(*reply, output);
 }
 
 template <typename Output>
-inline long long RedisCluster::zscan(const StringView &key,
-                                long long cursor,
-                                const StringView &pattern,
-                                Output output) {
+inline Cursor RedisCluster::zscan(const StringView &key,
+                             Cursor cursor,
+                             const StringView &pattern,
+                             Output output) {
     return zscan(key, cursor, pattern, 10, output);
 }
 
 template <typename Output>
-inline long long RedisCluster::zscan(const StringView &key,
-                                long long cursor,
-                                long long count,
-                                Output output) {
+inline Cursor RedisCluster::zscan(const StringView &key,
+                             Cursor cursor,
+                             long long count,
+                             Output output) {
     return zscan(key, cursor, "*", count, output);
 }
 
 template <typename Output>
-inline long long RedisCluster::zscan(const StringView &key,
-                                long long cursor,
-                                Output output) {
+inline Cursor RedisCluster::zscan(const StringView &key,
+                             Cursor cursor,
+                             Output output) {
     return zscan(key, cursor, "*", 10, output);
 }
 

--- a/src/sw/redis++/reply.h
+++ b/src/sw/redis++/reply.h
@@ -115,7 +115,7 @@ template <typename T, typename std::enable_if<IsAssociativeContainer<T>::value, 
 T parse(ParseTag<T>, redisReply &reply);
 
 template <typename Output>
-long long parse_scan_reply(redisReply &reply, Output output);
+Cursor parse_scan_reply(redisReply &reply, Output output);
 
 inline bool is_error(redisReply &reply) {
     return reply.type == REDIS_REPLY_ERROR;
@@ -455,7 +455,7 @@ T parse(ParseTag<T>, redisReply &reply) {
 }
 
 template <typename Output>
-long long parse_scan_reply(redisReply &reply, Output output) {
+Cursor parse_scan_reply(redisReply &reply, Output output) {
     if (reply.elements != 2 || reply.element == nullptr) {
         throw ProtoError("Invalid scan reply");
     }
@@ -467,9 +467,9 @@ long long parse_scan_reply(redisReply &reply, Output output) {
     }
 
     auto cursor_str = reply::parse<std::string>(*cursor_reply);
-    long long new_cursor = 0;
+    Cursor new_cursor = 0;
     try {
-        new_cursor = std::stoll(cursor_str);
+        new_cursor = std::stoull(cursor_str);
     } catch (const std::exception &e) {
         throw ProtoError("Invalid cursor reply: " + cursor_str);
     }

--- a/test/src/sw/redis++/hash_cmds_test.hpp
+++ b/test/src/sw/redis++/hash_cmds_test.hpp
@@ -149,7 +149,7 @@ void HashCmdTest<RedisInstance>::_test_hscan() {
     _redis.hmset(key, items.begin(), items.end());
 
     std::unordered_map<std::string, std::string> item_map;
-    auto cursor = 0;
+    Cursor cursor = 0;
     while (true) {
         cursor = _redis.hscan(key, cursor, "f*", 2, std::inserter(item_map, item_map.end()));
         if (cursor == 0) {

--- a/test/src/sw/redis++/keys_cmds_test.hpp
+++ b/test/src/sw/redis++/keys_cmds_test.hpp
@@ -145,7 +145,7 @@ void KeysCmdTest<RedisInstance>::_test_scan(Redis &instance) {
     instance.set(k2, "v");
     instance.set(k3, "v");
 
-    auto cursor = 0;
+    Cursor cursor = 0;
     std::unordered_set<std::string> res;
     while (true) {
         cursor = instance.scan(cursor, "*" + key_pattern + "*", 2, std::inserter(res, res.end()));

--- a/test/src/sw/redis++/set_cmds_test.hpp
+++ b/test/src/sw/redis++/set_cmds_test.hpp
@@ -153,7 +153,7 @@ void SetCmdTest<RedisInstance>::_test_sscan() {
     _redis.sadd(key, members.begin(), members.end());
 
     std::unordered_set<std::string> res;
-    long long cursor = 0;
+    Cursor cursor = 0;
     while (true) {
         cursor = _redis.sscan(key, cursor, "m*", 1, std::inserter(res, res.end()));
         if (cursor == 0) {

--- a/test/src/sw/redis++/zset_cmds_test.hpp
+++ b/test/src/sw/redis++/zset_cmds_test.hpp
@@ -103,7 +103,7 @@ void ZSetCmdTest<RedisInstance>::_test_zscan() {
     _redis.zadd(key, s.begin(), s.end());
 
     std::map<std::string, double> res;
-    auto cursor = 0;
+    Cursor cursor = 0;
     while (true) {
         cursor = _redis.zscan(key, cursor, "m*", 2, std::inserter(res, res.end()));
         if (cursor == 0) {


### PR DESCRIPTION
We faced the issue when the `SCAN` command returned too big value for `long long` type which led to the error `Invalid cursor reply: 9286422431637963776`. This happened with AWS ElastiCache (Redis). According to the [documentation](https://redis.io/docs/latest/commands/scan/):

> SCAN, SSCAN, HSCAN and ZSCAN return a two element multi-bulk reply, where the first element is a string representing an **unsigned 64 bit number** (the cursor), and the second element is a multi-bulk with an array of elements.

Also, the same issue was fixed for Spring: https://github.com/spring-projects/spring-data-redis/issues/2796

I realize this change is quite big and probably a braking change, but I believe we need to fix it. So I replaced all `long long` cursors with `Cursor` alias which is `unsigned long long`. Probably it's better to use `std::uint64_t` to be more precise. 