### PR TITLE
Add available() function to subscriber

### DIFF
--- a/src/sw/redis++/connection.cpp
+++ b/src/sw/redis++/connection.cpp
@@ -273,7 +273,6 @@ bool Connection::avail() {
     } else {
         // An error occurred
         throw_error(*ctx, strerror(errno));
-        return -1;
     }
 }
 

--- a/src/sw/redis++/connection.h
+++ b/src/sw/redis++/connection.h
@@ -145,6 +145,8 @@ public:
 
     ReplyUPtr recv(bool handle_error_reply = true);
 
+    bool avail();
+
     const ConnectionOptions& options() const {
         return _opts;
     }

--- a/src/sw/redis++/subscriber.cpp
+++ b/src/sw/redis++/subscriber.cpp
@@ -127,6 +127,12 @@ void Subscriber::consume() {
     }
 }
 
+bool Subscriber::available() {
+    _check_connection();
+
+    return _connection.avail();
+}
+
 Subscriber::MsgType Subscriber::_msg_type(redisReply *reply) const {
     if (reply == nullptr) {
         throw ProtoError("Null type reply.");

--- a/src/sw/redis++/subscriber.h
+++ b/src/sw/redis++/subscriber.h
@@ -163,6 +163,8 @@ public:
 
     void consume();
 
+    bool available();
+
 private:
     friend class Redis;
 


### PR DESCRIPTION
I am using redis++ for an application with a redis backend. We rely on pubsub for some communication between different processes.

Currently, we use socket_timeout and a loop to consume messages. This has some drawbacks however.
1. If other work comes in (not via redis) it can only be handled after the socket_timeout expires
2. I cannot check if the subscriber has a message without blocking

Therefor, I created a method in subscriber that calls a non-blocking poll call on the hiredis file descriptor.