### PR TITLE
Fix a static analysis warning

### DIFF
--- a/src/sw/redis++/reply.h
+++ b/src/sw/redis++/reply.h
@@ -309,7 +309,7 @@ template <typename T, typename ...Args>
 auto parse_variant(redisReply &reply) ->
     typename std::enable_if<sizeof...(Args) != 0, Variant<T, Args...>>::type {
     auto return_var = [](auto &&arg) {
-        return Variant<T, Args...>(std::move(arg));
+        return Variant<T, Args...>(std::forward<decltype(arg)>(arg));
     };
 
     try {


### PR DESCRIPTION
`reply.h`: `std::move` was used where `std::forward` should be used

Fixes #589