### PR TITLE
Fix some implicit conversions

### DIFF
--- a/src/sw/redis++/connection.cpp
+++ b/src/sw/redis++/connection.cpp
@@ -128,7 +128,7 @@ void Connection::Connector::_set_socket_timeout(redisContext &ctx) const {
 void Connection::Connector::_enable_keep_alive(redisContext &ctx) const {
 #ifdef REDIS_PLUS_PLUS_HAS_redisEnableKeepAliveWithInterval
     if (_opts.keep_alive_s > std::chrono::seconds{0}) {
-        if (redisEnableKeepAliveWithInterval(&ctx, _opts.keep_alive_s.count()) != REDIS_OK) {
+        if (redisEnableKeepAliveWithInterval(&ctx, static_cast<int>(_opts.keep_alive_s.count())) != REDIS_OK) {
             throw_error(ctx, "Failed to enable keep alive option");
         }
 

--- a/src/sw/redis++/patterns/redlock.cpp
+++ b/src/sw/redis++/patterns/redlock.cpp
@@ -191,11 +191,11 @@ std::string RedLockUtils::lock_id() {
     for (int i = 0; i != 20; ++i) {
         auto idx = dist(random_gen);
         if (idx < 10) {
-            id.push_back('0' + idx);
+            id.push_back(static_cast<char>('0' + idx));
         } else if (idx < 10 + 26) {
-            id.push_back('a' + idx - 10);
+            id.push_back(static_cast<char>('a' + idx - 10));
         } else if (idx < 10 + 26 + 26) {
-            id.push_back('A' + idx - 10 - 26);
+            id.push_back(static_cast<char>('A' + idx - 10 - 26));
         } else {
             assert(false && "Index out of range in RedLock::_lock_id()");
         }
@@ -280,7 +280,7 @@ RedLockMutexVessel::LockInfo RedLockMutexVessel::lock(const std::string& resourc
             }
         }
 
-        const auto drift = std::chrono::milliseconds(int(ttl.count() * clock_drift_factor) + 2);
+        const auto drift = std::chrono::duration<decltype(clock_drift_factor)>(ttl) * clock_drift_factor + std::chrono::milliseconds(2);
         lock_info.time_remaining = std::chrono::duration_cast<std::chrono::milliseconds>
             (lock_info.startTime + ttl - std::chrono::steady_clock::now() - drift);
 
@@ -319,7 +319,8 @@ RedLockMutexVessel::LockInfo RedLockMutexVessel::extend_lock(const RedLockMutexV
                     num_locked++;
                 }
             }
-            const auto drift = std::chrono::milliseconds(int(ttl.count() * clock_drift_factor) + 2);
+
+            const auto drift = std::chrono::duration<decltype(clock_drift_factor)>(ttl) * clock_drift_factor + std::chrono::milliseconds(2);
             extended_lock_info.time_remaining = std::chrono::duration_cast<std::chrono::milliseconds>
                 (extended_lock_info.startTime + ttl - std::chrono::steady_clock::now() - drift);
 

--- a/src/sw/redis++/patterns/redlock.h
+++ b/src/sw/redis++/patterns/redlock.h
@@ -259,7 +259,7 @@ private:
                           const std::string& random_string);
 
     int _quorum() const {
-        return _instances.size() / 2 + 1;
+        return static_cast<int>(_instances.size() / 2 + 1);
     }
 
     std::vector<std::shared_ptr<Redis>> _instances;

--- a/src/sw/redis++/redis_uri.cpp
+++ b/src/sw/redis++/redis_uri.cpp
@@ -86,7 +86,7 @@ void Uri::_set_option(const std::string &key, const std::string &val) {
     } else if (key == "resp") {
         _opts.resp = _parse_int_option(val);
     } else if (key == "pool_size") {
-        _pool_opts.size = _parse_int_option(val);
+        _pool_opts.size = static_cast<std::size_t>(_parse_int_option(val));
     } else if (key == "pool_wait_timeout") {
         _pool_opts.wait_timeout = _parse_timeout_option(val);
     } else if (key == "pool_connection_lifetime") {


### PR DESCRIPTION
Made it possible to compile with `-Wshadow -Wconversion -Wcast-qual -Wsign-conversion`. Silenced the warnings that would pop up with a `static_cast`.

The `chrono` conversion warning that would pop up was silenced by staying within the `chrono` domain instead of doing a cast.