### PR TITLE
fix: hiredis build on window workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -74,7 +74,7 @@ jobs:
       working-directory: ${{ steps.strings.outputs.build-output-dir }}
       run: ./test/test_redis++ -h 127.0.0.1 -p 6379 -n 127.0.0.1 -c 7000
 
-  windows-test:
+  windows:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -97,15 +97,7 @@ jobs:
             .. && `
           ninja -v && `
           ninja install
-  
-  windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: install deps
-        run: choco install -y ninja memurai-developer
-
-      - uses: ilammy/msvc-dev-cmd@v1
-      - name: build hiredis
-        run: mkdir build && cd build && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${{ github.workspace }}/install .. && ninja -v && ninja install
+      - name: Test
+        working-directory: ${{ github.workspace }}/build
+        run: |
+          .\test\test_redis++ -h 127.0.0.1 -p 6379 -n 127.0.0.1 -c 7000

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -82,16 +82,20 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Install ninja and memurai
         run: choco install -y ninja memurai-developer
+
       - name: Set up vcpkg
         run: |
           git clone https://github.com/microsoft/vcpkg.git vcpkg
           .\vcpkg\bootstrap-vcpkg.bat
+  
       - name: Install Hiredis using vcpkg
         run: .\vcpkg\vcpkg install hiredis
+
       - uses: ilammy/msvc-dev-cmd@v1
-      - name: Build hiredis and your project
+      - name: build hiredis
         run: |
           mkdir build
           cd build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,8 +3,12 @@ name: build and test
 on:
   push:
     branches: [ "master", "dev" ]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches: [ "master", "dev" ]
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   build:
@@ -32,7 +36,7 @@ jobs:
             cpp_compiler: clang++
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: libuv-dep
       run: sudo apt-get update && sudo apt-get install -y libuv1-dev wget unzip
@@ -97,7 +101,3 @@ jobs:
             .. && `
           ninja -v && `
           ninja install
-      - name: Test
-        working-directory: ${{ github.workspace }}/build
-        run: |
-          .\test\test_redis++ -h 127.0.0.1 -p 6379 -n 127.0.0.1 -c 7000

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -78,27 +78,26 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-
       - name: Install ninja and memurai
         run: choco install -y ninja memurai-developer
-
       - name: Set up vcpkg
         run: |
           git clone https://github.com/microsoft/vcpkg.git vcpkg
           .\vcpkg\bootstrap-vcpkg.bat
-
       - name: Install Hiredis using vcpkg
         run: .\vcpkg\vcpkg install hiredis
-
       - uses: ilammy/msvc-dev-cmd@v1
-
       - name: Build hiredis and your project
         run: |
           mkdir build
           cd build
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${{ github.workspace }}/install;${{ github.workspace }}/vcpkg/installed/x64-windows .. && ninja -v && ninja install
-
-
+          cmake -G Ninja `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install;${{ github.workspace }}/vcpkg/installed/x64-windows" `
+            .. && `
+          ninja -v && `
+          ninja install
+  
   windows:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -74,6 +74,31 @@ jobs:
       working-directory: ${{ steps.strings.outputs.build-output-dir }}
       run: ./test/test_redis++ -h 127.0.0.1 -p 6379 -n 127.0.0.1 -c 7000
 
+  windows-test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ninja and memurai
+        run: choco install -y ninja memurai-developer
+
+      - name: Set up vcpkg
+        run: |
+          git clone https://github.com/microsoft/vcpkg.git vcpkg
+          .\vcpkg\bootstrap-vcpkg.bat
+
+      - name: Install Hiredis using vcpkg
+        run: .\vcpkg\vcpkg install hiredis
+
+      - uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Build hiredis and your project
+        run: |
+          mkdir build
+          cd build
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${{ github.workspace }}/install;${{ github.workspace }}/vcpkg/installed/x64-windows .. && ninja -v && ninja install
+
+
   windows:
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
- fix windows build workflow issue
- Update actions/checkout from v3 to v4
- Ignore .md files from triggering the workflow, to reduce unnecessary builds or tests when documentation files are updated