### PR TITLE
Allow user specified host in connection with sentinel

### DIFF
--- a/README.md
+++ b/README.md
@@ -2340,7 +2340,7 @@ Besides `std::shared_ptr<Sentinel>` and master name, you also need to specify a 
 
 With `Role::MASTER`, *redis-plus-plus* will always connect to current master instance, even if a failover occurs. Each time when *redis-plus-plus* needs to create a new connection to master, or a connection is broken, and it needs to reconnect to master, *redis-plus-plus* will ask master address from Redis Sentinel, and connects to current master. If a failover occurs, *redis-plus-plus* can automatically get the address of the new master, and refresh all connections in the underlying connection pool.
 
-Similarly, with `Role::SLAVE`, *redis-plus-plus* will always connect to a slave instance. A master might have several slaves, *redis-plus-plus* will randomly pick one, and connect to it, i.e. all connections in the underlying connection pool, connect to the same slave instance (check [this discussion](https://github.com/sewenew/redis-plus-plus/issues/99) on why *redis-plus-plus* not connect to all slaves). If the connection is broken, while this slave instance is still an alive slave, *redis-plus-plus* will reconnect to this slave. However, if this slave instance is down, or it has been promoted to be the master, *redis-plus-plus* will randomly connect to another slave. If there's no slave alive, it throws an exception.
+Similarly, with `Role::SLAVE`, *redis-plus-plus* will always connect to a slave instance. A master might have several slaves, *redis-plus-plus* will randomly pick one (unless user has provided a specific host in the connection options, see [example below](#specifying-slave-host)), and connect to it, i.e. all connections in the underlying connection pool, connect to the same slave instance (check [this discussion](https://github.com/sewenew/redis-plus-plus/issues/99) on why *redis-plus-plus* not connect to all slaves). If the connection is broken, while this slave instance is still an alive slave, *redis-plus-plus* will reconnect to this slave. However, if this slave instance is down, or it has been promoted to be the master, *redis-plus-plus* will randomly connect to another slave. If there's no slave alive, it throws an exception.
 
 #### Create Redis With Sentinel
 
@@ -2360,6 +2360,8 @@ auto redis = Redis(sentinel, "master_name", Role::MASTER, connection_opts, pool_
 
 You might have noticed that we didn't specify the `host` and `port` fields for `ConnectionOptions`. Because, `Redis` will get these info from Redis Sentinel. Also, in this case, `ConnectionOptions::connect_timeout` and `ConnectionOptions::socket_timeout` CANNOT be 0ms, otherwise, it throws an exception. So you always need to specify these two timeouts manually.
 
+**NOTE**: it is recommended **not** to specify `host` and `port` fields, unless you know what you are doing. See example [below](#specifying-slave-host)
+
 After creating the `Redis` object with sentinel, you can send commands with it, just like an ordinary `Redis` object.
 
 If you want to write to master, and scale read with slaves. You can use the following pattern:
@@ -2377,6 +2379,26 @@ master.set("key", "value");
 // Read from slave.
 slave.get("key");
 ```
+
+##### Specifying slave host
+
+The following pattern could be used to specify slave host to connect to:
+
+```C++
+auto sentinel = std::make_shared<Sentinel>(sentinel_opts);
+
+// Specifying preferred host to connect to
+connection_opts.host = "127.0.0.1";
+connection_opts.port = 6379;
+auto slave = Redis(sentinel, "master_name", Role::SLAVE, connection_opts, pool_opts);
+
+// Try read from specified slave.
+slave.get("key");
+```
+
+In this example `Sentinel` will verify that specified host is available and has appropriate role. If host is unavailable or has been elected as master, then we will use same failover mechanism as shown above - connect to randomly selected host from available replicas
+
+**NOTE**: It is usually better **not** to specify host to connect to. But it can be benefitial for some use cases, e.g. if hosts are physicaly located on different servers and you know that ping to one of them is significaly lower than to others
 
 ### Redis Stream
 

--- a/src/sw/redis++/async_connection_pool.cpp
+++ b/src/sw/redis++/async_connection_pool.cpp
@@ -85,9 +85,6 @@ AsyncConnectionPool::AsyncConnectionPool(SimpleAsyncSentinel sentinel,
         throw Error("With sentinel, connection timeout and socket timeout cannot be 0");
     }
 
-    // Cleanup connection options.
-    _update_connection_opts("", -1);
-
     assert(_sentinel);
 }
 

--- a/src/sw/redis++/connection_pool.cpp
+++ b/src/sw/redis++/connection_pool.cpp
@@ -49,9 +49,6 @@ ConnectionPool::ConnectionPool(SimpleSentinel sentinel,
         throw Error("With sentinel, connection timeout and socket timeout cannot be 0");
     }
 
-    // Cleanup connection options.
-    _update_connection_opts("", -1);
-
     assert(_sentinel);
 }
 


### PR DESCRIPTION
Hi! It's my first time contributing to an open source project, so feel free to point out if i made something wrong

### What is the problem?

I am trying to use redis as an external cache for latency-critical application that is scaled on three different physical servers

So for each application instance situation looks like this:

We have one redis instance that is available locally and two redis instances that are available but will cost a few net hops to reach (we want to avoid that at all costs). Preferred behavior is to always send readonly operations to local redis instance if possible, and if it is not alive, then we must go to any other available instance

The main issue is net latency with `Redis` client created with `Sentinel` and configured to read from `Role::SLAVE` because it chooses random host, but I want to specify preferred one

### Suggestion

Allow user to specify host+port in `ConnectionOptions` and if it is suitable according to configuration, then use it

If user leaves host unspecified the behavior of connection pool with sentinel will be the same - randomly choose host from available replicas

### Example

Before changes:

```c++
// Assume that we are running on server-1 and redis-instance-1 has the least network delay
connection_opts.host = "redis-instance-1";
connection_opts.port = 6379;
// While creating ConnectionPool we silently ignore host specified by user earlier
auto slave = Redis(sentinel, "master_name", Role::SLAVE, connection_opts, pool_opts);
slave.get("key");  // Possible net hops, random
```

After changes

```c++
// Assume that we are running on server-1 and redis-instance-1 has the least network delay 
connection_opts.host = "redis-instance-1";
connection_opts.port = 6379;
// Not ignoring host specified by user
auto slave = Redis(sentinel, "master_name", Role::SLAVE, connection_opts, pool_opts);
slave.get("key");  // Guaranteed low latency if redis-instance-1 is alive and is has role "slave"
```


```c++
// The same behavior as before changes: 
connection_opts.host = "";  // Set to empty string or leave unspecified
auto slave = Redis(sentinel, "master_name", Role::SLAVE, connection_opts, pool_opts);
slave.get("key");  // Connect to randomly selected replica
```