### PR TITLE
Change timeouts to double for blocking list commands

### DIFF
--- a/src/sw/redis++/async_redis.h
+++ b/src/sw/redis++/async_redis.h
@@ -514,13 +514,13 @@ public:
     // LIST commands.
 
     Future<OptionalStringPair> blpop(const StringView &key,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return _command<OptionalStringPair>(fmt::blpop, key, timeout);
     }
 
     template <typename Callback>
     auto blpop(const StringView &key,
-               const std::chrono::seconds &timeout,
+               const std::chrono::duration<double> &timeout,
                Callback &&cb)
         -> typename std::enable_if<IsInvocable<typename std::decay<Callback>::type, Future<OptionalStringPair> &&>::value, void>::type {
         _callback_fmt_command<OptionalStringPair>(std::forward<Callback>(cb), fmt::blpop, key, timeout);
@@ -536,7 +536,7 @@ public:
     template <typename Input>
     Future<OptionalStringPair> blpop(Input first,
                                 Input last,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         range_check("BLPOP", first, last);
 
         return _command<OptionalStringPair>(fmt::blpop_range<Input>, first, last, timeout);
@@ -545,7 +545,7 @@ public:
     template <typename Input, typename Callback>
     auto blpop(Input first,
                Input last,
-               const std::chrono::seconds &timeout,
+               const std::chrono::duration<double> &timeout,
                Callback &&cb)
         -> typename std::enable_if<IsInvocable<typename std::decay<Callback>::type, Future<OptionalStringPair> &&>::value, void>::type {
         range_check("BLPOP", first, last);
@@ -563,13 +563,13 @@ public:
 
     template <typename T>
     Future<OptionalStringPair> blpop(std::initializer_list<T> il,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return blpop(il.begin(), il.end(), timeout);
     }
 
     template <typename T, typename Callback>
     auto blpop(std::initializer_list<T> il,
-               const std::chrono::seconds &timeout,
+               const std::chrono::duration<double> &timeout,
                Callback &&cb)
         -> typename std::enable_if<IsInvocable<typename std::decay<Callback>::type, Future<OptionalStringPair> &&>::value, void>::type {
         return blpop(il.begin(), il.end(), timeout, std::forward<Callback>(cb));
@@ -583,13 +583,13 @@ public:
     }
 
     Future<OptionalStringPair> brpop(const StringView &key,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return _command<OptionalStringPair>(fmt::brpop, key, timeout);
     }
 
     template <typename Callback>
     auto brpop(const StringView &key,
-               const std::chrono::seconds &timeout,
+               const std::chrono::duration<double> &timeout,
                Callback &&cb)
         -> typename std::enable_if<IsInvocable<typename std::decay<Callback>::type, Future<OptionalStringPair> &&>::value, void>::type {
         _callback_fmt_command<OptionalStringPair>(std::forward<Callback>(cb), fmt::brpop, key, timeout);
@@ -605,7 +605,7 @@ public:
     template <typename Input>
     Future<OptionalStringPair> brpop(Input first,
                                 Input last,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         range_check("BRPOP", first, last);
 
         return _command<OptionalStringPair>(fmt::brpop_range<Input>, first, last, timeout);
@@ -614,7 +614,7 @@ public:
     template <typename Input, typename Callback>
     auto brpop(Input first,
                Input last,
-               const std::chrono::seconds &timeout,
+               const std::chrono::duration<double> &timeout,
                Callback &&cb)
         -> typename std::enable_if<IsInvocable<typename std::decay<Callback>::type, Future<OptionalStringPair> &&>::value, void>::type {
         range_check("BRPOP", first, last);
@@ -632,13 +632,13 @@ public:
 
     template <typename T>
     Future<OptionalStringPair> brpop(std::initializer_list<T> il,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return brpop(il.begin(), il.end(), timeout);
     }
 
     template <typename T, typename Callback>
     auto brpop(std::initializer_list<T> il,
-               const std::chrono::seconds &timeout,
+               const std::chrono::duration<double> &timeout,
                Callback &&cb)
         -> typename std::enable_if<IsInvocable<typename std::decay<Callback>::type, Future<OptionalStringPair> &&>::value, void>::type {
         return brpop(il.begin(), il.end(), timeout, std::forward<Callback>(cb));
@@ -653,14 +653,14 @@ public:
 
     Future<OptionalString> brpoplpush(const StringView &source,
                                 const StringView &destination,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return _command<OptionalString>(fmt::brpoplpush, source, destination, timeout);
     }
 
     template <typename Callback>
     auto brpoplpush(const StringView &source,
                     const StringView &destination,
-                    const std::chrono::seconds &timeout,
+                    const std::chrono::duration<double> &timeout,
                     Callback &&cb)
         -> typename std::enable_if<IsInvocable<typename std::decay<Callback>::type, Future<OptionalString> &&>::value, void>::type {
         _callback_fmt_command<OptionalString>(std::forward<Callback>(cb), fmt::brpoplpush, source, destination, timeout);
@@ -846,14 +846,14 @@ public:
 
     Future<OptionalString> blmove(const StringView &src, const StringView &dest,
             ListWhence src_whence, ListWhence dest_whence,
-            const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+            const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return _command<OptionalString>(fmt::blmove, src, dest, src_whence, dest_whence, timeout.count());
     }
 
     template <typename Callback>
     void blmove(const StringView &src, const StringView &dest,
             ListWhence src_whence, ListWhence dest_whence,
-            const std::chrono::seconds &timeout, Callback &&cb) {
+            const std::chrono::duration<double> &timeout, Callback &&cb) {
         _callback_fmt_command<OptionalString>(std::forward<Callback>(cb), fmt::blmove, src, dest,
                 src_whence, dest_whence, timeout.count());
     }

--- a/src/sw/redis++/async_redis_cluster.h
+++ b/src/sw/redis++/async_redis_cluster.h
@@ -387,14 +387,14 @@ public:
     // LIST commands.
 
     Future<OptionalStringPair> blpop(const StringView &key,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return _command<OptionalStringPair>(fmt::blpop, key, timeout);
     }
 
     template <typename Input>
     Future<OptionalStringPair> blpop(Input first,
                                 Input last,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         range_check("BLPOP", first, last);
 
         return _command<OptionalStringPair>(fmt::blpop_range<Input>, first, last, timeout);
@@ -402,19 +402,19 @@ public:
 
     template <typename T>
     Future<OptionalStringPair> blpop(std::initializer_list<T> il,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return blpop(il.begin(), il.end(), timeout);
     }
 
     Future<OptionalStringPair> brpop(const StringView &key,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return _command<OptionalStringPair>(fmt::brpop, key, timeout);
     }
 
     template <typename Input>
     Future<OptionalStringPair> brpop(Input first,
                                 Input last,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         range_check("BRPOP", first, last);
 
         return _command<OptionalStringPair>(fmt::brpop_range<Input>, first, last, timeout);
@@ -422,13 +422,13 @@ public:
 
     template <typename T>
     Future<OptionalStringPair> brpop(std::initializer_list<T> il,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return brpop(il.begin(), il.end(), timeout);
     }
 
     Future<OptionalString> brpoplpush(const StringView &source,
                                 const StringView &destination,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return _command<OptionalString>(fmt::brpoplpush, source, destination, timeout);
     }
 
@@ -528,14 +528,14 @@ public:
 
     Future<OptionalString> blmove(const StringView &src, const StringView &dest,
             ListWhence src_whence, ListWhence dest_whence,
-            const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+            const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return _command<OptionalString>(fmt::blmove, src, dest, src_whence, dest_whence, timeout.count());
     }
 
     template <typename Callback>
     void blmove(const StringView &src, const StringView &dest,
             ListWhence src_whence, ListWhence dest_whence,
-            const std::chrono::seconds &timeout, Callback &&cb) {
+            const std::chrono::duration<double> &timeout, Callback &&cb) {
         _callback_fmt_command<OptionalString>(std::forward<Callback>(cb), fmt::blmove, src, dest,
                 src_whence, dest_whence, timeout.count());
     }

--- a/src/sw/redis++/cmd_formatter.h
+++ b/src/sw/redis++/cmd_formatter.h
@@ -281,12 +281,12 @@ inline FormattedCommand strlen(const StringView &key) {
     return format_cmd("STRLEN %b", key.data(), key.size());
 }
 
-inline FormattedCommand blpop(const StringView &key, const std::chrono::seconds &timeout) {
-    return format_cmd("BLPOP %b %lld", key.data(), key.size(), timeout.count());
+inline FormattedCommand blpop(const StringView &key, const std::chrono::duration<double> &timeout) {
+    return format_cmd("BLPOP %b %f", key.data(), key.size(), timeout.count());
 }
 
 template <typename Input>
-FormattedCommand blpop_range(Input first, Input last, const std::chrono::seconds &timeout) {
+FormattedCommand blpop_range(Input first, Input last, const std::chrono::duration<double> &timeout) {
     assert(first != last);
 
     CmdArgs args;
@@ -295,13 +295,13 @@ FormattedCommand blpop_range(Input first, Input last, const std::chrono::seconds
     return format_cmd(args);
 }
 
-inline FormattedCommand brpop(const StringView &key, const std::chrono::seconds &timeout) {
-    return format_cmd("BRPOP %b %lld", key.data(), key.size(), timeout.count());
+inline FormattedCommand brpop(const StringView &key, const std::chrono::duration<double> &timeout) {
+    return format_cmd("BRPOP %b %f", key.data(), key.size(), timeout.count());
 }
 
 
 template <typename Input>
-FormattedCommand brpop_range(Input first, Input last, const std::chrono::seconds &timeout) {
+FormattedCommand brpop_range(Input first, Input last, const std::chrono::duration<double> &timeout) {
     assert(first != last);
 
     CmdArgs args;
@@ -312,8 +312,8 @@ FormattedCommand brpop_range(Input first, Input last, const std::chrono::seconds
 
 inline FormattedCommand brpoplpush(const StringView &source,
         const StringView &destination,
-        const std::chrono::seconds &timeout) {
-    return format_cmd("BRPOPLPUSH %b %b %lld",
+        const std::chrono::duration<double> &timeout) {
+    return format_cmd("BRPOPLPUSH %b %b %f",
             source.data(), source.size(),
             destination.data(), destination.size(),
             timeout.count());
@@ -401,10 +401,10 @@ inline FormattedCommand lmove(const StringView &src, const StringView &dest,
 }
 
 inline FormattedCommand blmove(const StringView &src, const StringView &dest,
-        ListWhence src_whence, ListWhence dest_whence, long long timeout) {
+        ListWhence src_whence, ListWhence dest_whence, double timeout) {
     auto src_whence_str = to_string(src_whence);
     auto dest_whence_str = to_string(dest_whence);
-    return format_cmd("BLMOVE %b %b %s %s %lld",
+    return format_cmd("BLMOVE %b %b %s %s %f",
             src.data(), src.size(),
             dest.data(), dest.size(),
             src_whence_str.data(), dest_whence_str.data(), timeout);

--- a/src/sw/redis++/command.h
+++ b/src/sw/redis++/command.h
@@ -464,8 +464,8 @@ inline void strlen(Connection &connection, const StringView &key) {
 
 // LIST commands.
 
-inline void blpop(Connection &connection, const StringView &key, long long timeout) {
-    connection.send("BLPOP %b %lld",
+inline void blpop(Connection &connection, const StringView &key, double timeout) {
+    connection.send("BLPOP %b %f",
                     key.data(), key.size(),
                     timeout);
 }
@@ -474,7 +474,7 @@ template <typename Input>
 inline void blpop_range(Connection &connection,
                         Input first,
                         Input last,
-                        long long timeout) {
+                        double timeout) {
     assert(first != last);
 
     CmdArgs args;
@@ -483,8 +483,8 @@ inline void blpop_range(Connection &connection,
     connection.send(args);
 }
 
-inline void brpop(Connection &connection, const StringView &key, long long timeout) {
-    connection.send("BRPOP %b %lld",
+inline void brpop(Connection &connection, const StringView &key, double timeout) {
+    connection.send("BRPOP %b %f",
                     key.data(), key.size(),
                     timeout);
 }
@@ -493,7 +493,7 @@ template <typename Input>
 inline void brpop_range(Connection &connection,
                         Input first,
                         Input last,
-                        long long timeout) {
+                        double timeout) {
     assert(first != last);
 
     CmdArgs args;
@@ -505,8 +505,8 @@ inline void brpop_range(Connection &connection,
 inline void brpoplpush(Connection &connection,
                         const StringView &source,
                         const StringView &destination,
-                        long long timeout) {
-    connection.send("BRPOPLPUSH %b %b %lld",
+                        double timeout) {
+    connection.send("BRPOPLPUSH %b %b %f",
                     source.data(), source.size(),
                     destination.data(), destination.size(),
                     timeout);
@@ -660,10 +660,10 @@ inline void lmove(Connection &connection, const StringView &src, const StringVie
 }
 
 inline void blmove(Connection &connection, const StringView &src, const StringView &dest,
-        ListWhence src_whence, ListWhence dest_whence, long long timeout) {
+        ListWhence src_whence, ListWhence dest_whence, double timeout) {
     auto src_whence_str = to_string(src_whence);
     auto dest_whence_str = to_string(dest_whence);
-    connection.send("BLMOVE %b %b %s %s %lld",
+    connection.send("BLMOVE %b %b %s %s %f",
                     src.data(), src.size(),
                     dest.data(), dest.size(),
                     src_whence_str.data(), dest_whence_str.data(), timeout);

--- a/src/sw/redis++/queued_redis.h
+++ b/src/sw/redis++/queued_redis.h
@@ -500,83 +500,83 @@ public:
 
     // LIST commands.
 
-    QueuedRedis& blpop(const StringView &key, long long timeout) {
+    QueuedRedis& blpop(const StringView &key, double timeout) {
         return command(cmd::blpop, key, timeout);
     }
 
     QueuedRedis& blpop(const StringView &key,
-                        const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                        const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return blpop(key, timeout.count());
     }
 
     template <typename Input>
-    QueuedRedis& blpop(Input first, Input last, long long timeout) {
+    QueuedRedis& blpop(Input first, Input last, double timeout) {
         range_check("BLPOP", first, last);
 
         return command(cmd::blpop_range<Input>, first, last, timeout);
     }
 
     template <typename T>
-    QueuedRedis& blpop(std::initializer_list<T> il, long long timeout) {
+    QueuedRedis& blpop(std::initializer_list<T> il, double timeout) {
         return blpop(il.begin(), il.end(), timeout);
     }
 
     template <typename Input>
     QueuedRedis& blpop(Input first,
                         Input last,
-                        const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                        const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return blpop(first, last, timeout.count());
     }
 
     template <typename T>
     QueuedRedis& blpop(std::initializer_list<T> il,
-                        const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                        const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return blpop(il.begin(), il.end(), timeout);
     }
 
-    QueuedRedis& brpop(const StringView &key, long long timeout) {
+    QueuedRedis& brpop(const StringView &key, double timeout) {
         return command(cmd::brpop, key, timeout);
     }
 
     QueuedRedis& brpop(const StringView &key,
-                        const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                        const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return brpop(key, timeout.count());
     }
 
     template <typename Input>
-    QueuedRedis& brpop(Input first, Input last, long long timeout) {
+    QueuedRedis& brpop(Input first, Input last, double timeout) {
         range_check("BRPOP", first, last);
 
         return command(cmd::brpop_range<Input>, first, last, timeout);
     }
 
     template <typename T>
-    QueuedRedis& brpop(std::initializer_list<T> il, long long timeout) {
+    QueuedRedis& brpop(std::initializer_list<T> il, double timeout) {
         return brpop(il.begin(), il.end(), timeout);
     }
 
     template <typename Input>
     QueuedRedis& brpop(Input first,
                         Input last,
-                        const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                        const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return brpop(first, last, timeout.count());
     }
 
     template <typename T>
     QueuedRedis& brpop(std::initializer_list<T> il,
-                        const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                        const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return brpop(il.begin(), il.end(), timeout);
     }
 
     QueuedRedis& brpoplpush(const StringView &source,
                             const StringView &destination,
-                            long long timeout) {
+                            double timeout) {
         return command(cmd::brpoplpush, source, destination, timeout);
     }
 
     QueuedRedis& brpoplpush(const StringView &source,
                             const StringView &destination,
-                            const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                            const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return brpoplpush(source, destination, timeout.count());
     }
 

--- a/src/sw/redis++/redis.cpp
+++ b/src/sw/redis++/redis.cpp
@@ -406,29 +406,29 @@ long long Redis::strlen(const StringView &key) {
 
 // LIST commands.
 
-OptionalStringPair Redis::blpop(const StringView &key, long long timeout) {
+OptionalStringPair Redis::blpop(const StringView &key, double timeout) {
     auto reply = command(cmd::blpop, key, timeout);
 
     return reply::parse<OptionalStringPair>(*reply);
 }
 
-OptionalStringPair Redis::blpop(const StringView &key, const std::chrono::seconds &timeout) {
+OptionalStringPair Redis::blpop(const StringView &key, const std::chrono::duration<double> &timeout) {
     return blpop(key, timeout.count());
 }
 
-OptionalStringPair Redis::brpop(const StringView &key, long long timeout) {
+OptionalStringPair Redis::brpop(const StringView &key, double timeout) {
     auto reply = command(cmd::brpop, key, timeout);
 
     return reply::parse<OptionalStringPair>(*reply);
 }
 
-OptionalStringPair Redis::brpop(const StringView &key, const std::chrono::seconds &timeout) {
+OptionalStringPair Redis::brpop(const StringView &key, const std::chrono::duration<double> &timeout) {
     return brpop(key, timeout.count());
 }
 
 OptionalString Redis::brpoplpush(const StringView &source,
                                     const StringView &destination,
-                                    long long timeout) {
+                                    double timeout) {
     auto reply = command(cmd::brpoplpush, source, destination, timeout);
 
     return reply::parse<OptionalString>(*reply);
@@ -523,7 +523,7 @@ OptionalString Redis::lmove(const StringView &src, const StringView &dest,
 }
 
 OptionalString Redis::blmove(const StringView &src, const StringView &dest,
-        ListWhence src_whence, ListWhence dest_whence, const std::chrono::seconds &timeout) {
+        ListWhence src_whence, ListWhence dest_whence, const std::chrono::duration<double> &timeout) {
     auto reply = command(cmd::blmove, src, dest, src_whence, dest_whence, timeout.count());
 
     return reply::parse<OptionalString>(*reply);

--- a/src/sw/redis++/redis.h
+++ b/src/sw/redis++/redis.h
@@ -976,7 +976,7 @@ public:
     /// @note If list is empty and timeout reaches, return `OptionalStringPair{}` (`std::nullopt`).
     /// @see `Redis::lpop`
     /// @see https://redis.io/commands/blpop
-    OptionalStringPair blpop(const StringView &key, long long timeout);
+    OptionalStringPair blpop(const StringView &key, double timeout);
 
     /// @brief Pop the first element of the list in a blocking way.
     /// @param key Key where the list is stored.
@@ -986,7 +986,7 @@ public:
     /// @see `Redis::lpop`
     /// @see https://redis.io/commands/blpop
     OptionalStringPair blpop(const StringView &key,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0});
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0});
 
     /// @brief Pop the first element of multiple lists in a blocking way.
     /// @param first Iterator to the first key.
@@ -997,7 +997,7 @@ public:
     /// @see `Redis::lpop`
     /// @see https://redis.io/commands/blpop
     template <typename Input>
-    OptionalStringPair blpop(Input first, Input last, long long timeout);
+    OptionalStringPair blpop(Input first, Input last, double timeout);
 
     /// @brief Pop the first element of multiple lists in a blocking way.
     /// @param il Initializer list of keys.
@@ -1007,7 +1007,7 @@ public:
     /// @see `Redis::lpop`
     /// @see https://redis.io/commands/blpop
     template <typename T>
-    OptionalStringPair blpop(std::initializer_list<T> il, long long timeout) {
+    OptionalStringPair blpop(std::initializer_list<T> il, double timeout) {
         return blpop(il.begin(), il.end(), timeout);
     }
 
@@ -1022,7 +1022,7 @@ public:
     template <typename Input>
     OptionalStringPair blpop(Input first,
                                 Input last,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0});
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0});
 
     /// @brief Pop the first element of multiple lists in a blocking way.
     /// @param il Initializer list of keys.
@@ -1033,7 +1033,7 @@ public:
     /// @see https://redis.io/commands/blpop
     template <typename T>
     OptionalStringPair blpop(std::initializer_list<T> il,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return blpop(il.begin(), il.end(), timeout);
     }
 
@@ -1044,7 +1044,7 @@ public:
     /// @note If list is empty and timeout reaches, return `OptionalStringPair{}` (`std::nullopt`).
     /// @see `Redis::rpop`
     /// @see https://redis.io/commands/brpop
-    OptionalStringPair brpop(const StringView &key, long long timeout);
+    OptionalStringPair brpop(const StringView &key, double timeout);
 
     /// @brief Pop the last element of the list in a blocking way.
     /// @param key Key where the list is stored.
@@ -1054,7 +1054,7 @@ public:
     /// @see `Redis::rpop`
     /// @see https://redis.io/commands/brpop
     OptionalStringPair brpop(const StringView &key,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0});
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0});
 
     /// @brief Pop the last element of multiple lists in a blocking way.
     /// @param first Iterator to the first key.
@@ -1065,7 +1065,7 @@ public:
     /// @see `Redis::rpop`
     /// @see https://redis.io/commands/brpop
     template <typename Input>
-    OptionalStringPair brpop(Input first, Input last, long long timeout);
+    OptionalStringPair brpop(Input first, Input last, double timeout);
 
     /// @brief Pop the last element of multiple lists in a blocking way.
     /// @param il Initializer list of lists.
@@ -1075,7 +1075,7 @@ public:
     /// @see `Redis::rpop`
     /// @see https://redis.io/commands/brpop
     template <typename T>
-    OptionalStringPair brpop(std::initializer_list<T> il, long long timeout) {
+    OptionalStringPair brpop(std::initializer_list<T> il, double timeout) {
         return brpop(il.begin(), il.end(), timeout);
     }
 
@@ -1090,7 +1090,7 @@ public:
     template <typename Input>
     OptionalStringPair brpop(Input first,
                                 Input last,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0});
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0});
 
     /// @brief Pop the last element of multiple lists in a blocking way.
     /// @param il Initializer list of list keys.
@@ -1101,7 +1101,7 @@ public:
     /// @see https://redis.io/commands/brpop
     template <typename T>
     OptionalStringPair brpop(std::initializer_list<T> il,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return brpop(il.begin(), il.end(), timeout);
     }
 
@@ -1115,7 +1115,7 @@ public:
     /// @see https://redis.io/commands/brpoplpush
     OptionalString brpoplpush(const StringView &source,
                                 const StringView &destination,
-                                long long timeout);
+                                double timeout);
 
     /// @brief Pop last element of one list and push it to the left of another list in blocking way.
     /// @param source Key of the source list.
@@ -1127,7 +1127,7 @@ public:
     /// @see https://redis.io/commands/brpoplpush
     OptionalString brpoplpush(const StringView &source,
                                 const StringView &destination,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0});
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0});
 
     /// @brief Get the element at the given index of the list.
     /// @param key Key where the list is stored.
@@ -1387,7 +1387,7 @@ public:
     /// @see https://redis.io/commands/blmove
     OptionalString blmove(const StringView &src, const StringView &dest,
             ListWhence src_whence, ListWhence dest_whence,
-            const std::chrono::seconds &timeout = std::chrono::seconds{0});
+            const std::chrono::duration<double> &timeout = std::chrono::seconds{0});
 
     // HASH commands.
 

--- a/src/sw/redis++/redis.hpp
+++ b/src/sw/redis++/redis.hpp
@@ -277,7 +277,7 @@ inline void Redis::setex(const StringView &key,
 // LIST commands.
 
 template <typename Input>
-OptionalStringPair Redis::blpop(Input first, Input last, long long timeout) {
+OptionalStringPair Redis::blpop(Input first, Input last, double timeout) {
     range_check("BLPOP", first, last);
 
     auto reply = command(cmd::blpop_range<Input>, first, last, timeout);
@@ -288,12 +288,12 @@ OptionalStringPair Redis::blpop(Input first, Input last, long long timeout) {
 template <typename Input>
 OptionalStringPair Redis::blpop(Input first,
                                 Input last,
-                                const std::chrono::seconds &timeout) {
+                                const std::chrono::duration<double> &timeout) {
     return blpop(first, last, timeout.count());
 }
 
 template <typename Input>
-OptionalStringPair Redis::brpop(Input first, Input last, long long timeout) {
+OptionalStringPair Redis::brpop(Input first, Input last, double timeout) {
     range_check("BRPOP", first, last);
 
     auto reply = command(cmd::brpop_range<Input>, first, last, timeout);
@@ -304,13 +304,13 @@ OptionalStringPair Redis::brpop(Input first, Input last, long long timeout) {
 template <typename Input>
 OptionalStringPair Redis::brpop(Input first,
                                 Input last,
-                                const std::chrono::seconds &timeout) {
+                                const std::chrono::duration<double> &timeout) {
     return brpop(first, last, timeout.count());
 }
 
 inline OptionalString Redis::brpoplpush(const StringView &source,
                                         const StringView &destination,
-                                        const std::chrono::seconds &timeout) {
+                                        const std::chrono::duration<double> &timeout) {
     return brpoplpush(source, destination, timeout.count());
 }
 

--- a/src/sw/redis++/redis_cluster.cpp
+++ b/src/sw/redis++/redis_cluster.cpp
@@ -317,29 +317,29 @@ long long RedisCluster::strlen(const StringView &key) {
 
 // LIST commands.
 
-OptionalStringPair RedisCluster::blpop(const StringView &key, long long timeout) {
+OptionalStringPair RedisCluster::blpop(const StringView &key, double timeout) {
     auto reply = command(cmd::blpop, key, timeout);
 
     return reply::parse<OptionalStringPair>(*reply);
 }
 
-OptionalStringPair RedisCluster::blpop(const StringView &key, const std::chrono::seconds &timeout) {
+OptionalStringPair RedisCluster::blpop(const StringView &key, const std::chrono::duration<double> &timeout) {
     return blpop(key, timeout.count());
 }
 
-OptionalStringPair RedisCluster::brpop(const StringView &key, long long timeout) {
+OptionalStringPair RedisCluster::brpop(const StringView &key, double timeout) {
     auto reply = command(cmd::brpop, key, timeout);
 
     return reply::parse<OptionalStringPair>(*reply);
 }
 
-OptionalStringPair RedisCluster::brpop(const StringView &key, const std::chrono::seconds &timeout) {
+OptionalStringPair RedisCluster::brpop(const StringView &key, const std::chrono::duration<double> &timeout) {
     return brpop(key, timeout.count());
 }
 
 OptionalString RedisCluster::brpoplpush(const StringView &source,
                                     const StringView &destination,
-                                    long long timeout) {
+                                    double timeout) {
     auto reply = command(cmd::brpoplpush, source, destination, timeout);
 
     return reply::parse<OptionalString>(*reply);
@@ -434,7 +434,7 @@ OptionalString RedisCluster::lmove(const StringView &src, const StringView &dest
 }
 
 OptionalString RedisCluster::blmove(const StringView &src, const StringView &dest,
-        ListWhence src_whence, ListWhence dest_whence, const std::chrono::seconds &timeout) {
+        ListWhence src_whence, ListWhence dest_whence, const std::chrono::duration<double> &timeout) {
     auto reply = command(cmd::blmove, src, dest, src_whence, dest_whence, timeout.count());
 
     return reply::parse<OptionalString>(*reply);

--- a/src/sw/redis++/redis_cluster.h
+++ b/src/sw/redis++/redis_cluster.h
@@ -299,61 +299,61 @@ public:
 
     // LIST commands.
 
-    OptionalStringPair blpop(const StringView &key, long long timeout);
+    OptionalStringPair blpop(const StringView &key, double timeout);
 
     OptionalStringPair blpop(const StringView &key,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0});
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0});
 
     template <typename Input>
-    OptionalStringPair blpop(Input first, Input last, long long timeout);
+    OptionalStringPair blpop(Input first, Input last, double timeout);
 
     template <typename T>
-    OptionalStringPair blpop(std::initializer_list<T> il, long long timeout) {
+    OptionalStringPair blpop(std::initializer_list<T> il, double timeout) {
         return blpop(il.begin(), il.end(), timeout);
     }
 
     template <typename Input>
     OptionalStringPair blpop(Input first,
                                 Input last,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0});
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0});
 
     template <typename T>
     OptionalStringPair blpop(std::initializer_list<T> il,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return blpop(il.begin(), il.end(), timeout);
     }
 
-    OptionalStringPair brpop(const StringView &key, long long timeout);
+    OptionalStringPair brpop(const StringView &key, double timeout);
 
     OptionalStringPair brpop(const StringView &key,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0});
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0});
 
     template <typename Input>
-    OptionalStringPair brpop(Input first, Input last, long long timeout);
+    OptionalStringPair brpop(Input first, Input last, double timeout);
 
     template <typename T>
-    OptionalStringPair brpop(std::initializer_list<T> il, long long timeout) {
+    OptionalStringPair brpop(std::initializer_list<T> il, double timeout) {
         return brpop(il.begin(), il.end(), timeout);
     }
 
     template <typename Input>
     OptionalStringPair brpop(Input first,
                                 Input last,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0});
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0});
 
     template <typename T>
     OptionalStringPair brpop(std::initializer_list<T> il,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0}) {
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0}) {
         return brpop(il.begin(), il.end(), timeout);
     }
 
     OptionalString brpoplpush(const StringView &source,
                                 const StringView &destination,
-                                long long timeout);
+                                double timeout);
 
     OptionalString brpoplpush(const StringView &source,
                                 const StringView &destination,
-                                const std::chrono::seconds &timeout = std::chrono::seconds{0});
+                                const std::chrono::duration<double> &timeout = std::chrono::seconds{0});
 
     OptionalString lindex(const StringView &key, long long index);
 
@@ -416,7 +416,7 @@ public:
 
     OptionalString blmove(const StringView &src, const StringView &dest,
             ListWhence src_whence, ListWhence dest_whence,
-            const std::chrono::seconds &timeout = std::chrono::seconds{0});
+            const std::chrono::duration<double> &timeout = std::chrono::seconds{0});
 
     // HASH commands.
 

--- a/src/sw/redis++/redis_cluster.hpp
+++ b/src/sw/redis++/redis_cluster.hpp
@@ -248,7 +248,7 @@ inline void RedisCluster::setex(const StringView &key,
 // LIST commands.
 
 template <typename Input>
-OptionalStringPair RedisCluster::blpop(Input first, Input last, long long timeout) {
+OptionalStringPair RedisCluster::blpop(Input first, Input last, double timeout) {
     range_check("BLPOP", first, last);
 
     auto reply = command(cmd::blpop_range<Input>, first, last, timeout);
@@ -259,12 +259,12 @@ OptionalStringPair RedisCluster::blpop(Input first, Input last, long long timeou
 template <typename Input>
 OptionalStringPair RedisCluster::blpop(Input first,
                                 Input last,
-                                const std::chrono::seconds &timeout) {
+                                const std::chrono::duration<double> &timeout) {
     return blpop(first, last, timeout.count());
 }
 
 template <typename Input>
-OptionalStringPair RedisCluster::brpop(Input first, Input last, long long timeout) {
+OptionalStringPair RedisCluster::brpop(Input first, Input last, double timeout) {
     range_check("BRPOP", first, last);
 
     auto reply = command(cmd::brpop_range<Input>, first, last, timeout);
@@ -275,13 +275,13 @@ OptionalStringPair RedisCluster::brpop(Input first, Input last, long long timeou
 template <typename Input>
 OptionalStringPair RedisCluster::brpop(Input first,
                                 Input last,
-                                const std::chrono::seconds &timeout) {
+                                const std::chrono::duration<double> &timeout) {
     return brpop(first, last, timeout.count());
 }
 
 inline OptionalString RedisCluster::brpoplpush(const StringView &source,
                                         const StringView &destination,
-                                        const std::chrono::seconds &timeout) {
+                                        const std::chrono::duration<double> &timeout) {
     return brpoplpush(source, destination, timeout.count());
 }
 


### PR DESCRIPTION
Since redis 6.0.0, blocking list commands accept doubles as timeouts instead of integers.

This pull request updates the following parameters for the commands `blpop`, `brpop`, `brpoplpush` and `blmove`:
* `long long timeout` to `double timeout`
* `std::chrono::seconds` to `std::chrono::duration<double>`
