### PR TITLE
Allow hiredis to be retrieved automatically by FetchContent

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         build_type: [Release]
+        redis_version: [7.2.8]
         c_compiler: [gcc, clang]
         include:
           - os: ubuntu-latest
@@ -39,12 +40,21 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: libuv-dep
-      run: sudo apt-get update && sudo apt-get install -y libuv1-dev wget unzip
+      run: |
+        sudo apt-get update
+        sudo apt-get install -yq libuv1-dev wget unzip
 
     - name: redis-dep
       run: |
-        wget -L https://github.com/redis/redis/archive/refs/tags/7.2.3.zip -O redis-7.2.3.zip && unzip redis-7.2.3.zip
-        cd redis-7.2.3 && make -j2 && ./src/redis-server --port 7000 --cluster-enabled yes --cluster-config-file nodes-7000.conf --daemonize yes && ./src/redis-server --port 7001 --cluster-enabled yes --cluster-config-file nodes-7001.conf --daemonize yes && ./src/redis-server --port 7002 --cluster-enabled yes --cluster-config-file nodes-7002.conf --daemonize yes && ./src/redis-cli --cluster-yes --cluster create 127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 && ./src/redis-server --daemonize yes
+        wget -L https://github.com/redis/redis/archive/refs/tags/${{matrix.redis_version}}.zip -O redis-${{matrix.redis_version}}.zip
+        unzip redis-${{matrix.redis_version}}.zip
+        cd redis-${{matrix.redis_version}}
+        make -j2
+        ./src/redis-server --port 7000 --cluster-enabled yes --cluster-config-file nodes-7000.conf --daemonize yes
+        ./src/redis-server --port 7001 --cluster-enabled yes --cluster-config-file nodes-7001.conf --daemonize yes
+        ./src/redis-server --port 7002 --cluster-enabled yes --cluster-config-file nodes-7002.conf --daemonize yes
+        sleep 2
+        ./src/redis-cli --cluster-yes --cluster create 127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 && ./src/redis-server --daemonize yes
 
     - name: hiredis-dep
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,28 +139,7 @@ else()
 endif()
 
 # hiredis dependency
-find_package(hiredis QUIET)
-if(hiredis_FOUND)
-    list(APPEND REDIS_PLUS_PLUS_HIREDIS_LIBS hiredis::hiredis)
-
-    if(REDIS_PLUS_PLUS_USE_TLS)
-        find_package(hiredis_ssl REQUIRED)
-        list(APPEND REDIS_PLUS_PLUS_HIREDIS_LIBS hiredis::hiredis_ssl)
-        find_package(OpenSSL REQUIRED)
-        list(APPEND REDIS_PLUS_PLUS_HIREDIS_LIBS ${OPENSSL_LIBRARIES})
-    endif()
-else()
-    find_path(HIREDIS_HEADER hiredis)
-    find_library(HIREDIS_LIB hiredis)
-    list(APPEND REDIS_PLUS_PLUS_HIREDIS_LIBS ${HIREDIS_LIB})
-
-    if(REDIS_PLUS_PLUS_USE_TLS)
-        find_library(HIREDIS_TLS_LIB hiredis_ssl)
-        list(APPEND REDIS_PLUS_PLUS_HIREDIS_LIBS ${HIREDIS_TLS_LIB})
-        find_package(OpenSSL REQUIRED)
-        list(APPEND REDIS_PLUS_PLUS_HIREDIS_LIBS ${OPENSSL_LIBRARIES})
-    endif()
-endif()
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/FindHiredis.cmake)
 
 # Check hiredis features
 message(STATUS "redis-plus-plus check hiredis features")
@@ -174,8 +153,9 @@ endif()
 set(HIREDIS_FEATURE_TEST_HEADER "${HIREDIS_FEATURE_TEST_INCLUDE}/hiredis/hiredis.h")
 
 include(CheckSymbolExists)
-set(CMAKE_REQUIRED_LIBRARIES_BACK ${CMAKE_REQUIRED_LIBRARIES})
-set(CMAKE_REQUIRED_LIBRARIES ${HIREDIS_FEATURE_TEST_LIB})
+
+# Add hiredis to CMAKE_REQUIRED_LIBRARIES
+list(APPEND CMAKE_REQUIRED_LIBRARIES hiredis)
 
 CHECK_SYMBOL_EXISTS(redisEnableKeepAliveWithInterval ${HIREDIS_FEATURE_TEST_HEADER} REDIS_PLUS_PLUS_HAS_redisEnableKeepAliveWithInterval)
 
@@ -183,7 +163,7 @@ set(REDIS_PLUS_PLUS_GENERATED_HEADER_DIR ${CMAKE_CURRENT_BINARY_DIR}/${REDIS_PLU
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/hiredis_features.h.in ${CMAKE_CURRENT_BINARY_DIR}/${REDIS_PLUS_PLUS_SOURCE_DIR}/hiredis_features.h)
 
 # Restore CMAKE_REQUIRED_LIBRARIES
-set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES_BACK})
+list(POP_BACK CMAKE_REQUIRED_LIBRARIES)
 
 # Build static library
 option(REDIS_PLUS_PLUS_BUILD_STATIC "Build static library" ON)
@@ -273,11 +253,10 @@ if(REDIS_PLUS_PLUS_BUILD_SHARED)
 
     if(hiredis_FOUND)
         target_include_directories(${SHARED_LIB} PUBLIC $<BUILD_INTERFACE:${hiredis_INCLUDE_DIRS}>)
-        target_link_libraries(${SHARED_LIB} PUBLIC ${REDIS_PLUS_PLUS_HIREDIS_LIBS})
     else()
         target_include_directories(${SHARED_LIB} PUBLIC $<BUILD_INTERFACE:${HIREDIS_HEADER}>)
-        target_link_libraries(${SHARED_LIB} PUBLIC ${REDIS_PLUS_PLUS_HIREDIS_LIBS})
     endif()
+    target_link_libraries(${SHARED_LIB} PUBLIC ${REDIS_PLUS_PLUS_HIREDIS_LIBS})
 
     if(REDIS_PLUS_PLUS_BUILD_ASYNC)
         target_include_directories(${SHARED_LIB} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${REDIS_PLUS_PLUS_ASYNC_FUTURE_HEADER}>)

--- a/cmake/FindHiredis.cmake
+++ b/cmake/FindHiredis.cmake
@@ -1,0 +1,38 @@
+find_package(hiredis QUIET)
+if(hiredis_FOUND)
+    list(APPEND REDIS_PLUS_PLUS_HIREDIS_LIBS hiredis::hiredis)
+
+    if(NOT hiredis_INCLUDE_DIRS)
+        # This can happen when hiredis is included with FetchContent with OVERRIDE_FIND_PACKAGE
+        find_path(
+          hiredis_INCLUDE_DIRS
+          hiredis.h
+          PATHS
+            ${CMAKE_BINARY_DIR}/_deps/hiredis
+            ${CMAKE_CURRENT_BINARY_DIR}/_deps/hiredis
+          NO_CACHE
+          REQUIRED
+        )
+
+        # Remove the trailing /hiredis from the include path so that we can include hiredis with hiredis/hiredis.h
+        get_filename_component(hiredis_INCLUDE_DIRS "${hiredis_INCLUDE_DIRS}" DIRECTORY)
+    endif()
+
+    if(REDIS_PLUS_PLUS_USE_TLS)
+        find_package(hiredis_ssl REQUIRED)
+        list(APPEND REDIS_PLUS_PLUS_HIREDIS_LIBS hiredis::hiredis_ssl)
+        find_package(OpenSSL REQUIRED)
+        list(APPEND REDIS_PLUS_PLUS_HIREDIS_LIBS ${OPENSSL_LIBRARIES})
+    endif()
+else()
+    find_path(HIREDIS_HEADER hiredis)
+    find_library(HIREDIS_LIB hiredis)
+    list(APPEND REDIS_PLUS_PLUS_HIREDIS_LIBS ${HIREDIS_LIB})
+
+    if(REDIS_PLUS_PLUS_USE_TLS)
+        find_library(HIREDIS_TLS_LIB hiredis_ssl)
+        list(APPEND REDIS_PLUS_PLUS_HIREDIS_LIBS ${HIREDIS_TLS_LIB})
+        find_package(OpenSSL REQUIRED)
+        list(APPEND REDIS_PLUS_PLUS_HIREDIS_LIBS ${OPENSSL_LIBRARIES})
+    endif()
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,17 +7,9 @@ set(REDIS_PLUS_PLUS_TEST_SOURCES src/sw/redis++/test_main.cpp)
 add_executable(${PROJECT_NAME} ${REDIS_PLUS_PLUS_TEST_SOURCES})
 
 # hiredis dependency
-find_path(HIREDIS_HEADER hiredis REQUIRED)
-target_include_directories(${PROJECT_NAME} PRIVATE $<BUILD_INTERFACE:${HIREDIS_HEADER}>)
+include(${CMAKE_CURRENT_LIST_DIR}/../cmake/FindHiredis.cmake)
 
-find_library(TEST_HIREDIS_LIB NAMES libhiredis.a libhiredisd.a)
-if(NOT TEST_HIREDIS_LIB)
-    find_library(TEST_HIREDIS_LIB NAMES libhiredis_static.a libhiredis_staticd.a)
-    if(NOT TEST_HIREDIS_LIB)
-        find_library(TEST_HIREDIS_LIB NAMES hiredis hiredisd)
-    endif()
-endif()
-target_link_libraries(${PROJECT_NAME} ${TEST_HIREDIS_LIB})
+target_link_libraries(${PROJECT_NAME} ${REDIS_PLUS_PLUS_HIREDIS_LIBS})
 
 if(REDIS_PLUS_PLUS_USE_TLS)
     find_package(OpenSSL REQUIRED)


### PR DESCRIPTION
Configure hiredis features file before find package of hiredis to avoid configuration error.

Fix issues encountered by [this PR](https://github.com/sewenew/redis-plus-plus/pull/352), and this [issue](https://github.com/redis/hiredis/issues/1119).

Here's how to use FetchContent with `redis++` as a dependency with modern CMake (>= v3.24):

**CMakeLists.txt**
```
cmake_minimum_required(VERSION 3.24)
project(examples LANGUAGES CXX)

include(FetchContent)

FetchContent_Declare(
  hiredis
  GIT_REPOSITORY https://github.com/redis/hiredis
  GIT_TAG origin/master
  GIT_SHALLOW TRUE
  SOURCE_DIR _deps/hiredis
  # Make sure redis++ finds fetched content with its find_package()
  OVERRIDE_FIND_PACKAGE
)

FetchContent_Declare(
  redis-plus-plus
  GIT_REPOSITORY https://github.com/sjanel/redis-plus-plus.git
  GIT_TAG bugfix/hiredis-fetch-configure-file-found
  GIT_SHALLOW TRUE
)
FetchContent_MakeAvailable(redis-plus-plus)


add_executable(main
  main.cc
)

target_link_libraries(main
  redis++
)
```

**main.cc**
```
#include <sw/redis++/redis++.h>
#include <iostream>

int main() {
  auto redis = sw::redis::Redis("tcp://127.0.0.1:6379");
  redis.set("key", "value");
  auto val = redis.get("key");
  if (val) {
    std::cout << "Got: " << *val << std::endl;
  }
  return 0;
}
```

(adapted from [this gist](https://gist.github.com/bjosv/6b61dbb11193fdfd36cbcc82473d1036))