### PR TITLE
add bind_cpu to EventLoop thread.

### DIFF
--- a/src/sw/redis++/event_loop.cpp
+++ b/src/sw/redis++/event_loop.cpp
@@ -59,6 +59,13 @@ void EventLoop::stop() {
     }
 }
 
+int EventLoop::bind_cpu(int cpu_id) {
+    cpu_set_t cpuset;
+    CPU_ZERO(&cpuset);
+    CPU_SET(cpu_id, &cpuset);
+    return pthread_setaffinity_np(_loop_thread.native_handle(), sizeof(cpu_set_t), &cpuset);
+}
+
 void EventLoop::unwatch(AsyncConnectionSPtr connection, std::exception_ptr err) {
     assert(connection);
 

--- a/src/sw/redis++/event_loop.cpp
+++ b/src/sw/redis++/event_loop.cpp
@@ -31,7 +31,10 @@ EventLoop::EventLoop() {
     _event_async = _create_uv_async(_event_callback);
     _stop_async = _create_uv_async(_stop_callback);
 
-    _loop_thread = std::thread([this]() { uv_run(this->_loop.get(), UV_RUN_DEFAULT); });
+    _loop_thread = std::thread([this]() { 
+        pthread_setname_np(pthread_self(), "redis-ev");
+        uv_run(this->_loop.get(), UV_RUN_DEFAULT); 
+    });
 }
 
 EventLoop::~EventLoop() {

--- a/src/sw/redis++/event_loop.h
+++ b/src/sw/redis++/event_loop.h
@@ -54,6 +54,8 @@ public:
 
     void stop();
 
+    int EventLoop::bind_cpu(int cpu_id)
+
 private:
     static void _connect_callback(const redisAsyncContext *ctx, int status);
 


### PR DESCRIPTION
Add a bind_cpu interface to EventLoop so that multiple AsyncRedis instances, the load can be distributed more evenly.
Also, assign a name to the EventLoop thread to make it easier to identify and debug.