### PR TITLE
Update libuv find & link configuration to support both static and sha…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ if(REDIS_PLUS_PLUS_BUILD_ASYNC)
         message(STATUS "redis-plus-plus build async interface with libuv")
 
         # libuv dependency
-        find_package(libuv NO_MODULE CONFIG)
+        find_package(libuv)
         if (NOT libuv_FOUND)
             find_path(REDIS_PLUS_PLUS_ASYNC_LIB_HEADER NAMES uv.h)
             find_library(REDIS_PLUS_PLUS_ASYNC_LIB uv)


### PR DESCRIPTION
The libuv library lookup can be explicitly specified by setting the libuv_DIR CMake variable to the directory containing the libuv's CMake config file (e.g. <libuv_install_prefix>/lib/cmake/libuv), which allows flexible custom selection of the libuv version/path for static & shared library linkage compatibility.