### PR TITLE
fix: 兼容 libuv 静态库(uv_a)和动态库(uv)的链接目标

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,13 @@ if(REDIS_PLUS_PLUS_BUILD_STATIC)
     if(REDIS_PLUS_PLUS_BUILD_ASYNC)
         target_include_directories(${STATIC_LIB} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${REDIS_PLUS_PLUS_ASYNC_FUTURE_HEADER}>)
         if(libuv_FOUND)
-            target_link_libraries(${STATIC_LIB} PUBLIC $<TARGET_NAME:libuv::uv>)
+            target_link_libraries(${STATIC_LIB} PUBLIC 
+                $<IF:$<TARGET_EXISTS:libuv::uv>, libuv::uv, 
+                    $<IF:$<TARGET_EXISTS:libuv::uv_a>, libuv::uv_a, 
+                        $<IF:$<TARGET_EXISTS:uv>, uv, uv_a>
+                    >
+                >
+            )
         else()
             target_include_directories(${STATIC_LIB} PUBLIC $<BUILD_INTERFACE:${REDIS_PLUS_PLUS_ASYNC_LIB_HEADER}>)
         endif()
@@ -263,7 +269,13 @@ if(REDIS_PLUS_PLUS_BUILD_SHARED)
     if(REDIS_PLUS_PLUS_BUILD_ASYNC)
         target_include_directories(${SHARED_LIB} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/${REDIS_PLUS_PLUS_ASYNC_FUTURE_HEADER}>)
         if(libuv_FOUND)
-            target_link_libraries(${SHARED_LIB} PUBLIC $<TARGET_NAME:libuv::uv>)
+            target_link_libraries(${SHARED_LIB} PUBLIC 
+                $<IF:$<TARGET_EXISTS:libuv::uv>, libuv::uv, 
+                    $<IF:$<TARGET_EXISTS:libuv::uv_a>, libuv::uv_a, 
+                        $<IF:$<TARGET_EXISTS:uv>, uv, uv_a>
+                    >
+                >
+            )
         else()
             target_include_directories(${SHARED_LIB} PUBLIC $<BUILD_INTERFACE:${REDIS_PLUS_PLUS_ASYNC_LIB_HEADER}>)
             target_link_libraries(${SHARED_LIB} PUBLIC ${REDIS_PLUS_PLUS_ASYNC_LIB})


### PR DESCRIPTION
修复仅适配 libuv 动态库(libuv::uv)导致静态库编译失败的问题，
通过多层嵌套的 CMake 生成器表达式自动检测目标名，
同时支持 libuv::uv/libuv::uv_a/uv/uv_a 四种常见目标命名，
实现静态库、动态库编译的全兼容。