### PR TITLE
Add Conan instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ I create a Redis module, named [redis-llm](https://github.com/sewenew/redis-llm)
     - [Install redis-plus-plus](#install-redis-plus-plus)
     - [Run Tests (Optional)](#run-tests-optional)
     - [Use redis-plus-plus In Your Project](#use-redis-plus-plus-in-your-project)
+    - [Install using Conan](#install-using-conan)
 - [Getting Started](#getting-started)
 - [API Reference](#api-reference)
     - [Connection](#connection)
@@ -379,6 +380,22 @@ The bechmark will generate `100` random binary keys for testing, and the size of
 ### Use redis-plus-plus In Your Project
 
 After compiling the code, you'll get both shared library and static library. Since *redis-plus-plus* depends on *hiredis*, you need to link both libraries to your Application. Also don't forget to specify the c++ standard, `-std=c++17`, `-std=c++14` or `-std=c++11`, as well as the thread-related option.
+
+### Install using Conan
+
+If you are using Conan, you can also install redis-plus-plus using Conan,
+instead of compiling it from source code.
+
+You can download and install redis-plus-plus from ConanCenter: using the [Conan](https://conan.io/) dependency manager:
+
+```
+conan install -r conancenter --requires="redis-plus-plus/[*]" --build=missing
+```
+
+The redis-plus-plus package in Conan Center is maintained by
+[ConanCenterIndex](https://github.com/conan-io/conan-center-index) community.
+If the version is out of date or the package does not work,
+please create an issue or pull request on the [Conan Center Index repository](https://github.com/conan-io/conan-center-index).
 
 #### Use Static Libraries
 


### PR DESCRIPTION
Greeting!

The redis-plus-plus project is now available on conan.io via https://github.com/conan-io/conan-center-index/pull/30359. See https://conan.io/center/recipes/redis-plus-plus?version=1.3.15 for extra information in the web interface.

I opened this new PR to provide a chance for users to learn how to install redis-plus-plus using Conan. So, avoiding all the manual build steps, including managing dependencies.

The pattern `redis-plus-plus/[*]` indicates "the latest version available".

Please let me know if it's okay, or if I should move it to another place. Regards!