### PR TITLE
allow injection of external libuv event loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -2749,10 +2749,12 @@ Future<void> fut2 = sub.psubscribe("pattern1*");
 
 **NOTE**: The following is an experimental feature, and might be modified or abandaned in the future.
 
-By default, `AsyncRedis` and `AsyncRedisCluster` create a default event loop, and runs the loop in a dedicated thread to handle read and write operations. However, you can also share the underlying event loop with multiple `AsyncRedis` and `AsyncRedisCluster` objects. In order to do that, you need to create a `std::shared_ptr<EventLoop>`, and pass it to the constructors of `AsyncRedis` and `AsyncRedisCluster`.
+By default, `AsyncRedis` and `AsyncRedisCluster` create a default event loop, and runs the loop in a dedicated thread to handle read and write operations. However, you can also share the underlying event loop with multiple `AsyncRedis` and `AsyncRedisCluster` objects. In order to do that, you need to create a `std::shared_ptr<EventLoop>`, and pass it to the constructors of `AsyncRedis` and `AsyncRedisCluster`. You can also inject an external libuv event loop.
 
 ```c++
 auto event_loop = std::make_shared<EventLoop>();
+// or:
+auto event_loop = std::make_shared<EventLoop>(externalLibuvLoop);
 
 auto redis = AsyncRedis(connection_opts, pool_opts, loop);
 

--- a/src/sw/redis++/async_connection.h
+++ b/src/sw/redis++/async_connection.h
@@ -283,6 +283,8 @@ struct AsyncContext {
     AsyncConnectionSPtr connection;
 
     bool run_disconnect_callback = true;
+
+    EventLoop* event_loop = nullptr;
 };
 
 template <typename Result, typename ResultParser>

--- a/src/sw/redis++/event_loop.cpp
+++ b/src/sw/redis++/event_loop.cpp
@@ -104,6 +104,12 @@ void EventLoop::watch(redisAsyncContext &ctx) {
 
     redisAsyncSetConnectCallback(&ctx, EventLoop::_connect_callback);
     redisAsyncSetDisconnectCallback(&ctx, EventLoop::_disconnect_callback);
+
+    auto *context = static_cast<AsyncContext *>(ctx.data);
+    if (context) {
+        context->event_loop = this;
+        _watch_count++;
+    }
 }
 
 void EventLoop::_connect_callback(const redisAsyncContext *ctx, int status) {
@@ -130,6 +136,11 @@ void EventLoop::_disconnect_callback(const redisAsyncContext *ctx, int status) {
 
     auto *context = static_cast<AsyncContext *>(ctx->data);
     assert(context != nullptr);
+
+    if (context->event_loop) {
+        context->event_loop->_watch_count--;
+        context->event_loop->_check_drain_complete();
+    }
 
     if (!context->run_disconnect_callback) {
         return;
@@ -180,6 +191,8 @@ void EventLoop::_event_callback(uv_async_t *handle) {
         // and this `disconnect` call will do nothing.
         connection->disconnect(err);
     }
+
+    event_loop->_check_drain_complete();
 }
 
 void EventLoop::_stop_callback(uv_async_t *handle) {
@@ -265,6 +278,31 @@ void EventLoop::LoopDeleter::operator()(uv_loop_t *loop) const {
     }
 
     delete loop;
+}
+
+void EventLoop::_check_drain_complete() {
+    if (!_draining || _watch_count > 0) return;
+
+    _draining = false;
+    // move out before calling: cb() may destroy this EventLoop
+    auto cb = std::move(_drain_callback);
+    if (cb) cb();
+}
+
+void EventLoop::drain(DrainCallback callback) {
+    assert(_external_loop);
+
+    // abort pending connect/command events immediately with an error
+    auto events = _get_events();
+    _clean_up(events.first, events.second);
+
+    _drain_callback = std::move(callback);
+    _draining = true;
+
+    // trigger _event_callback on the next iteration, which calls _check_drain_complete();
+    // this handles the zero-connection case and avoids firing the callback synchronously
+    // while still inside drain() itself
+    uv_async_send(_event_async.get());
 }
 
 void EventLoop::_notify() {

--- a/src/sw/redis++/event_loop.cpp
+++ b/src/sw/redis++/event_loop.cpp
@@ -34,6 +34,14 @@ EventLoop::EventLoop() {
     _loop_thread = std::thread([this]() { uv_run(this->_loop.get(), UV_RUN_DEFAULT); });
 }
 
+EventLoop::EventLoop(uv_loop_t* external_loop) {
+    _external_loop = external_loop;
+
+    _event_async = _create_uv_async(_event_callback);
+
+    // No background thread: the external loop drives execution
+}
+
 EventLoop::~EventLoop() {
     stop();
 }
@@ -49,10 +57,19 @@ void EventLoop::stop() {
         _stopped = true;
     }
 
-    _stop();
+    if (!_external_loop) {
+        _stop();
 
-    if (_loop_thread.joinable()) {
-        _loop_thread.join();
+        if (_loop_thread.joinable()) {
+            _loop_thread.join();
+        }
+    } else {
+        auto* event_async = _event_async.release();
+        if (event_async) {
+            uv_close(reinterpret_cast<uv_handle_t*>(event_async), [](uv_handle_t* handle) {
+                delete reinterpret_cast<uv_async_t*>(handle);
+            });
+        }
     }
 }
 
@@ -81,7 +98,7 @@ void EventLoop::add(AsyncConnectionSPtr event) {
 }
 
 void EventLoop::watch(redisAsyncContext &ctx) {
-    if (redisLibuvAttach(&ctx, _loop.get()) != REDIS_OK) {
+    if (redisLibuvAttach(&ctx, _get_loop()) != REDIS_OK) {
         throw Error("failed to attach to event loop");
     }
 
@@ -279,7 +296,7 @@ auto EventLoop::_get_events()
 
 EventLoop::UvAsyncUPtr EventLoop::_create_uv_async(AsyncCallback callback) {
     auto uv_async = std::unique_ptr<uv_async_t>(new uv_async_t);
-    auto err = uv_async_init(_loop.get(), uv_async.get(), callback);
+    auto err = uv_async_init(_get_loop(), uv_async.get(), callback);
     if (err != 0) {
         throw Error("failed to initialize async: " + _err_msg(err));
     }

--- a/src/sw/redis++/event_loop.h
+++ b/src/sw/redis++/event_loop.h
@@ -21,6 +21,7 @@
 #include <unordered_map>
 #include <memory>
 #include <exception>
+#include <functional>
 #include <mutex>
 #include <thread>
 #include <uv.h>
@@ -55,6 +56,12 @@ public:
     void watch(redisAsyncContext &ctx);
 
     void stop();
+
+    using DrainCallback = std::function<void()>;
+
+    // Abort pending connections with an error, then call callback once all
+    // hiredis poll handles have been closed. Only valid for external loops.
+    void drain(DrainCallback callback);
 
 private:
     static void _connect_callback(const redisAsyncContext *ctx, int status);
@@ -113,6 +120,13 @@ private:
     LoopUPtr _loop;
 
     uv_loop_t* _external_loop{nullptr};
+
+    DrainCallback _drain_callback;
+
+    int _watch_count{0};
+    bool _draining{false};
+
+    void _check_drain_complete();
 
     uv_loop_t* _get_loop() const noexcept {
         return _loop ? _loop.get() : _external_loop;

--- a/src/sw/redis++/event_loop.h
+++ b/src/sw/redis++/event_loop.h
@@ -37,6 +37,8 @@ class EventLoop {
 public:
     EventLoop();
 
+    explicit EventLoop(uv_loop_t* external_loop);
+
     EventLoop(const EventLoop &) = delete;
     EventLoop& operator=(const EventLoop &) = delete;
 
@@ -109,6 +111,12 @@ private:
 
     // _loop must be defined at last, since its destructor needs other data members.
     LoopUPtr _loop;
+
+    uv_loop_t* _external_loop{nullptr};
+
+    uv_loop_t* _get_loop() const noexcept {
+        return _loop ? _loop.get() : _external_loop;
+    }
 
     bool _stopped{false};
 };


### PR DESCRIPTION
For integrating redis-plus-plus directly into existing libuv event loops, the loop should be injectable.

I tried it now via `EventLoop::EventLoop(uv_loop_t* external_loop)` which seems to work fine also in production.

The second commit implements `EventLoop.drain()` for a graceful shutdown which is needed to cleanly exit the external loop.

Is there any chance to get it merged to upstream? :-)