### PR TITLE
implemented AsyncRedisCluster.eval() with callback

### DIFF
--- a/src/sw/redis++/async_redis_cluster.h
+++ b/src/sw/redis++/async_redis_cluster.h
@@ -1106,6 +1106,32 @@ public:
                 args.begin(), args.end());
     }
 
+    template <typename Result, typename Keys, typename Args, typename Callback>
+    auto eval(const StringView &script,
+              Keys keys_first,
+              Keys keys_last,
+              Args args_first,
+              Args args_last,
+              Callback &&cb)
+        -> typename std::enable_if<IsInvocable<typename std::decay<Callback>::type, Future<Result> &&>::value, void>::type {
+        if (keys_first == keys_last) {
+            throw Error("DO NOT support Lua script without key");
+        }
+
+        _callback_command_with_parser<Result, DefaultResultParser<Result>, Callback>(
+                std::forward<Callback>(cb), fmt::eval<Keys, Args>,
+                *keys_first, script, keys_first, keys_last, args_first, args_last);
+    }
+
+    template <typename Result, typename Callback>
+    auto eval(const StringView &script,
+              std::initializer_list<StringView> keys,
+              std::initializer_list<StringView> args,
+              Callback &&cb)
+        -> typename std::enable_if<IsInvocable<typename std::decay<Callback>::type, Future<Result> &&>::value, void>::type {
+        eval<Result>(script, keys.begin(), keys.end(), args.begin(), args.end(), std::forward<Callback>(cb));
+    }
+
     template <typename Result, typename Keys, typename Args>
     Future<Result> evalsha(const StringView &script,
                     Keys keys_first,


### PR DESCRIPTION
The `eval` wrapper functions in AsyncRedisCluster context miss the variants with callback. Is there any reason that they are missing? Or are they just "forgotten"? At least it works fine for us in production.